### PR TITLE
Expose State in prelude

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub use crate::manager::Manager;
 pub use libsignal_protocol::Context as ProtocolContext;
 
 pub mod prelude {
+    pub use crate::manager::State;
     pub use libsignal_protocol::{crypto::DefaultCrypto, Context};
     pub use libsignal_service::content::{
         self, sync_message, AttachmentPointer, ContentBody, DataMessage, GroupContextV2, Metadata,


### PR DESCRIPTION
Exposes the State enum in prelude so that the ConfigStore state can be properly matched against