### PR TITLE
Fix panic when receiving messages if the device is not registered.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,6 +24,8 @@ pub enum Error {
     ProfileManagerError(#[from] libsignal_service::ProfileManagerError),
     #[error("libsignal-service sending error: {0}")]
     MessageSenderError(#[from] libsignal_service::prelude::MessageSenderError),
+    #[error("libsignal-service error: {0}")]
+    MessageReceiverError(#[from] libsignal_service::receiver::MessageReceiverError),
     #[error("this client is already registered with Signal")]
     AlreadyRegisteredError,
     #[error("this client is not yet registered, please register or link as a secondary device")]


### PR DESCRIPTION
Also expose `is_registered` method and remove optional credentials
state.