### PR TITLE
Use a single ConfigStore param in Manager.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,12 @@ mod manager;
 pub use crate::errors::Error;
 pub use crate::manager::{Manager, State};
 
+/// Re-export of `libsignal-service` crate
+pub use libsignal_service;
+
+/// Re-export of Signal protobufs
+pub use libsignal_service::proto;
+
 pub mod prelude {
     pub mod service {
         pub use libsignal_service::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,14 +128,7 @@ async fn main() -> anyhow::Result<()> {
     let config_store = SledConfigStore::new(db_path)?;
 
     let csprng = rand::thread_rng();
-    let mut manager = Manager::new(
-        config_store.clone(),
-        config_store.clone(),
-        config_store.clone(),
-        config_store.clone(),
-        config_store,
-        csprng,
-    )?;
+    let mut manager = Manager::new(config_store, csprng)?;
 
     match args.subcommand {
         Subcommand::Register {


### PR DESCRIPTION
The ConfigStore trait already requires all other trais being
implmented, so there is no need to store them.

This also makes the random generator parameter default.