### PR TITLE
Expose downloading + decrypting attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Features:
 - [x] Link as secondary device from Android / iOS app (like Signal Desktop)
 - [x] Synchronize contacts from primary device (works, but not exposed currently)
 - [x] Receive messages
-- [ ] Fetch attachments (works, but not exposed currently)
+- [x] Download + decrypt attachments
 - [x] Send messages
 - [x] Groups support
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,6 +14,8 @@ pub enum Error {
     DbError(#[from] sled::Error),
     #[error("error decoding base64 data: {0}")]
     Base64Error(#[from] base64::DecodeError),
+    #[error("wrong slice size: {0}")]
+    TryFromSliceError(#[from] std::array::TryFromSliceError),
     #[error("phone number parsing error: {0}")]
     PhoneNumberError(#[from] libsignal_service::prelude::phonenumber::ParseError),
     #[error("UUID decoding error: {0}")]
@@ -44,4 +46,6 @@ pub enum Error {
     MessagePipeInterruptedError,
     #[error("failed to parse contact information: {0}")]
     ParseContactError(#[from] ParseContactError),
+    #[error("failed to decrypt attachment: {0}")]
+    AttachmentCipherError(#[from] libsignal_service::attachment_cipher::AttachmentCipherError),
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -734,10 +734,7 @@ where
 
         // We need the whole file for the crypto to check out
         let mut ciphertext = Vec::new();
-        let len = attachment_stream
-            .read_to_end(&mut ciphertext)
-            .await
-            .expect("streamed attachment");
+        let len = attachment_stream.read_to_end(&mut ciphertext).await?;
 
         trace!("downloaded encrypted attachment of {} bytes", len);
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -2,7 +2,7 @@ use std::{convert::TryInto, time::UNIX_EPOCH};
 
 use futures::{
     channel::mpsc::{channel, Sender},
-    future, pin_mut, SinkExt, Stream, StreamExt,
+    future, pin_mut, AsyncReadExt, SinkExt, Stream, StreamExt,
 };
 use image::Luma;
 use log::{error, trace, warn};
@@ -11,6 +11,7 @@ use rand::{distributions::Alphanumeric, CryptoRng, Rng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use libsignal_service::{
+    attachment_cipher::decrypt_in_place,
     cipher,
     configuration::{ServiceConfiguration, SignalServers, SignalingKey},
     content::{ContentBody, DataMessage, Metadata},
@@ -22,7 +23,7 @@ use libsignal_service::{
         protocol::{KeyPair, PrivateKey, PublicKey},
         Content, Envelope, GroupMasterKey, GroupSecretParams, PushService, Uuid,
     },
-    proto::{sync_message, SyncMessage},
+    proto::{sync_message, AttachmentPointer, SyncMessage},
     provisioning::{
         generate_registration_id, ConfirmCodeMessage, LinkingManager, ProvisioningManager,
         SecondaryDeviceProvisioning, VerificationCodeResponse,
@@ -722,6 +723,28 @@ where
         Ok(groups_v2_api
             .get_group(group_secret_params, authorization)
             .await?)
+    }
+
+    pub async fn get_attachment(
+        &self,
+        attachment_pointer: &AttachmentPointer,
+    ) -> Result<Vec<u8>, Error> {
+        let mut service = self.push_service()?;
+        let mut attachment_stream = service.get_attachment(&attachment_pointer).await?;
+
+        // We need the whole file for the crypto to check out
+        let mut ciphertext = Vec::new();
+        let len = attachment_stream
+            .read_to_end(&mut ciphertext)
+            .await
+            .expect("streamed attachment");
+
+        trace!("downloaded encrypted attachment of {} bytes", len);
+
+        let key: [u8; 64] = attachment_pointer.key().try_into()?;
+        decrypt_in_place(key, &mut ciphertext)?;
+
+        Ok(ciphertext)
     }
 
     /// Returns a clone of a cached push service.


### PR DESCRIPTION
The metadata is already part of the AttachmentPointer protobuf message.
This function downloads the attachment from the CDN and then decrypts it.