### PR TITLE
Expose ConfigStore trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod manager;
 #[cfg(feature = "sled-store")]
 pub use config::sled::SledConfigStore;
 
+pub use config::ConfigStore;
 pub use errors::Error;
 pub use manager::{Manager, State};
 


### PR DESCRIPTION
This commit exposes the ConfigStore trait publicly so that state can be queried