### PR TITLE
Use Send async_trait for SessionStoreExt

### DIFF
--- a/src/config/sled.rs
+++ b/src/config/sled.rs
@@ -323,7 +323,7 @@ impl SessionStore for SledConfigStore {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl SessionStoreExt for SledConfigStore {
     async fn get_sub_device_sessions(&self, name: &str) -> Result<Vec<u32>, SignalProtocolError> {
         let session_prefix = self.session_prefix(name);


### PR DESCRIPTION
Currently, presage does not build due to the recent changes to `libsignal-service`. This quick change allows the crate to compile.

Surprisingly, out of the five different instances of `#[async_trait(?Send)]`, this one is the only one that can actually be changed to `#[async_trait]`. All the others will fail to compile due to the `_ctx` pointer in the upstream `libsignal-client`. But for `SessionStoreExt` specifically, the change compiles out of the box. This works out quite nicely, as we can keep things building even while we are waiting on signalapp/libsignal-client#297.