### PR TITLE
First contact sync with UID

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -525,8 +525,8 @@ where
     /// Note: if this is successful, the contacts are not yet received & stored, and will only be
     /// processed when they're received using the `MessageReceiver`.
     pub async fn request_contacts_sync(&self) -> Result<(), Error> {
-        let phone_number = match &self.state {
-            State::Registered { phone_number, .. } => phone_number,
+        let uuid = match &self.state {
+            State::Registered { uuid, .. } => uuid,
             _ => return Err(Error::NotYetRegisteredError),
         };
 
@@ -542,8 +542,7 @@ where
             .expect("Time went backwards")
             .as_millis() as u64;
 
-        self.send_message(phone_number.clone(), sync_message, timestamp)
-            .await?;
+        self.send_message(uuid.clone(), sync_message, timestamp).await?;
 
         Ok(())
     }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -542,7 +542,8 @@ where
             .expect("Time went backwards")
             .as_millis() as u64;
 
-        self.send_message(uuid.clone(), sync_message, timestamp).await?;
+        self.send_message(uuid.clone(), sync_message, timestamp)
+            .await?;
 
         Ok(())
     }


### PR DESCRIPTION
When registering a new device and calling `request_contact_sync`, the `send_message` function is called with the user phone number as first argument.

However, this can't work since the store saves user information by uuid and not by phone number. If the keys aren't found in the store, then no encrypted message is given to the server and then, the request fails (http 404 error). It isn't critical but the register process partially fails.

I think that the `let phone_number = ...`  line and the last line should be replaced by something about uuid so it is possible to find the corresponding keys as proposed in this pull request.

Fixes #35 