### PR TITLE
Reexport States and uuid() function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,9 @@ pub use config::sled::SledConfigStore;
 
 pub use config::ConfigStore;
 pub use errors::Error;
-pub use manager::{Manager, RegistrationOptions};
+pub use manager::{
+    Confirmation, Linking, Manager, New, Registered, Registration, RegistrationOptions,
+};
 
 #[deprecated(note = "Please help use improve the prelude module instead")]
 pub use libsignal_service;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -502,6 +502,11 @@ where
         Ok(())
     }
 
+    /// Get the profile uuid
+    pub fn uuid(&self) -> Uuid {
+        self.state.uuid
+    }
+
     /// Fetches basic information on the registered device.
     pub async fn whoami(&self) -> Result<WhoAmIResponse, Error> {
         Ok(self.push_service()?.whoami().await?)


### PR DESCRIPTION
Since this commit [Rewrite Manager to use type states](https://github.com/whisperfish/presage/commit/55772b71b10c8b8dfb8f8e9e92f5339c4d4d7a57) , States are not exported anymore (usefull to be able to manipulate a manager outside of presage), and uuid() method was removed

thank you