### PR TITLE
Add a volatile store implementation

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,6 +11,8 @@ use crate::{manager::Registered, Error};
 #[cfg(feature = "sled-store")]
 pub mod sled;
 
+pub mod volatile;
+
 pub trait ConfigStore:
     PreKeyStore
     + SignedPreKeyStore
@@ -22,15 +24,15 @@ pub trait ConfigStore:
     + Clone
 {
     fn pre_keys_offset_id(&self) -> Result<u32, Error>;
-    fn set_pre_keys_offset_id(&self, id: u32) -> Result<(), Error>;
+    fn set_pre_keys_offset_id(&mut self, id: u32) -> Result<(), Error>;
 
     fn next_signed_pre_key_id(&self) -> Result<u32, Error>;
-    fn set_next_signed_pre_key_id(&self, id: u32) -> Result<(), Error>;
+    fn set_next_signed_pre_key_id(&mut self, id: u32) -> Result<(), Error>;
 }
 
 pub trait StateStore<S> {
     fn load_state(&self) -> Result<Registered, Error>;
-    fn save_state(&self, state: &S) -> Result<(), Error>;
+    fn save_state(&mut self, state: &S) -> Result<(), Error>;
 }
 
 pub trait ContactsStore {

--- a/src/config/sled.rs
+++ b/src/config/sled.rs
@@ -157,7 +157,7 @@ impl StateStore<Registered> for SledConfigStore {
         serde_json::from_slice(&data).map_err(Error::from)
     }
 
-    fn save_state(&self, state: &Registered) -> Result<(), Error> {
+    fn save_state(&mut self, state: &Registered) -> Result<(), Error> {
         let db = self.db.try_write().expect("poisoned mutex");
         db.clear()?;
         db.insert(SLED_KEY_REGISTRATION, serde_json::to_vec(state)?)?;
@@ -166,18 +166,11 @@ impl StateStore<Registered> for SledConfigStore {
 }
 
 impl ConfigStore for SledConfigStore {
-    // fn state(&self) -> Result<State, Error> {
-    //     let db = self.db.read().expect("poisoned mutex");
-    //     db.get(SLED_KEY_REGISTRATION)?.map_or(Ok(State::New), |s| {
-    //         serde_json::from_slice(&s).map_err(Error::from)
-    //     })
-    // }
-
     fn pre_keys_offset_id(&self) -> Result<u32, Error> {
         Ok(self.get_u32("pre_keys_offset_id")?.unwrap_or(0))
     }
 
-    fn set_pre_keys_offset_id(&self, id: u32) -> Result<(), Error> {
+    fn set_pre_keys_offset_id(&mut self, id: u32) -> Result<(), Error> {
         self.insert_u32("pre_keys_offset_id", id)
     }
 
@@ -185,7 +178,7 @@ impl ConfigStore for SledConfigStore {
         Ok(self.get_u32("next_signed_pre_key_id")?.unwrap_or(0))
     }
 
-    fn set_next_signed_pre_key_id(&self, id: u32) -> Result<(), Error> {
+    fn set_next_signed_pre_key_id(&mut self, id: u32) -> Result<(), Error> {
         self.insert_u32("next_signed_pre_key_id", id)
     }
 }

--- a/src/config/volatile.rs
+++ b/src/config/volatile.rs
@@ -1,0 +1,292 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use async_trait::async_trait;
+use libsignal_service::{
+    models::Contact,
+    prelude::{
+        protocol::{
+            Context, Direction, IdentityKey, IdentityKeyPair, IdentityKeyStore, PreKeyRecord,
+            PreKeyStore, ProtocolAddress, SessionRecord, SessionStore, SessionStoreExt,
+            SignalProtocolError, SignedPreKeyRecord, SignedPreKeyStore,
+        },
+        Uuid,
+    },
+};
+use log::{trace, warn};
+
+use super::{ConfigStore, ContactsStore, StateStore};
+use crate::{manager::Registered, Error};
+
+#[derive(Default, Debug, Clone)]
+pub struct VolatileConfigStore {
+    pre_keys_offset_id: u32,
+    next_signed_pre_key_id: u32,
+
+    pre_keys: HashMap<u32, Vec<u8>>,
+    signed_pre_keys: HashMap<u32, Vec<u8>>,
+
+    sessions: Arc<RwLock<HashMap<String, Vec<u8>>>>,
+    identities: Arc<RwLock<HashMap<ProtocolAddress, Vec<u8>>>>,
+
+    registration: Option<Vec<u8>>,
+}
+
+impl VolatileConfigStore {
+    fn session_key(&self, addr: &ProtocolAddress) -> String {
+        format!("session-{}", addr)
+    }
+
+    fn session_prefix(&self, name: &str) -> String {
+        format!("session-{}.", name)
+    }
+}
+
+impl StateStore<Registered> for VolatileConfigStore {
+    fn load_state(&self) -> Result<Registered, Error> {
+        let data = self
+            .registration
+            .as_ref()
+            .ok_or(Error::NotYetRegisteredError)?;
+        serde_json::from_slice(data).map_err(Error::from)
+    }
+
+    fn save_state(&mut self, state: &Registered) -> Result<(), Error> {
+        let data = serde_json::to_vec(state)?;
+        self.registration = Some(data);
+        Ok(())
+    }
+}
+
+impl ConfigStore for VolatileConfigStore {
+    fn pre_keys_offset_id(&self) -> Result<u32, Error> {
+        Ok(self.pre_keys_offset_id)
+    }
+
+    fn set_pre_keys_offset_id(&mut self, id: u32) -> Result<(), Error> {
+        self.pre_keys_offset_id = id;
+        Ok(())
+    }
+
+    fn next_signed_pre_key_id(&self) -> Result<u32, Error> {
+        Ok(self.next_signed_pre_key_id)
+    }
+
+    fn set_next_signed_pre_key_id(&mut self, id: u32) -> Result<(), Error> {
+        self.next_signed_pre_key_id = id;
+        Ok(())
+    }
+}
+
+impl ContactsStore for VolatileConfigStore {
+    fn save_contacts(&mut self, _: impl Iterator<Item = Contact>) -> Result<(), Error> {
+        warn!("contacts are not saved when using volatile storage.");
+        Ok(())
+    }
+
+    fn contacts(&self) -> Result<Vec<Contact>, Error> {
+        warn!("contacts are not saved when using volatile storage.");
+        Ok(vec![])
+    }
+
+    fn contact_by_id(&self, _: Uuid) -> Result<Option<Contact>, Error> {
+        warn!("contacts are not saved when using volatile storage.");
+        Ok(None)
+    }
+}
+
+#[async_trait(?Send)]
+impl PreKeyStore for VolatileConfigStore {
+    async fn get_pre_key(
+        &self,
+        prekey_id: u32,
+        _ctx: Context,
+    ) -> Result<PreKeyRecord, SignalProtocolError> {
+        let buf = self
+            .pre_keys
+            .get(&prekey_id)
+            .ok_or(SignalProtocolError::InvalidPreKeyId)?;
+        PreKeyRecord::deserialize(buf)
+    }
+
+    async fn save_pre_key(
+        &mut self,
+        prekey_id: u32,
+        record: &PreKeyRecord,
+        _ctx: Context,
+    ) -> Result<(), SignalProtocolError> {
+        self.pre_keys.insert(prekey_id, record.serialize()?);
+        Ok(())
+    }
+
+    async fn remove_pre_key(
+        &mut self,
+        prekey_id: u32,
+        _ctx: Context,
+    ) -> Result<(), SignalProtocolError> {
+        self.pre_keys.remove(&prekey_id);
+        Ok(())
+    }
+}
+
+#[async_trait(?Send)]
+impl SignedPreKeyStore for VolatileConfigStore {
+    async fn get_signed_pre_key(
+        &self,
+        signed_prekey_id: u32,
+        _ctx: Context,
+    ) -> Result<SignedPreKeyRecord, SignalProtocolError> {
+        let buf = self
+            .signed_pre_keys
+            .get(&signed_prekey_id)
+            .ok_or(SignalProtocolError::InvalidSignedPreKeyId)?;
+        SignedPreKeyRecord::deserialize(buf)
+    }
+
+    async fn save_signed_pre_key(
+        &mut self,
+        signed_prekey_id: u32,
+        record: &SignedPreKeyRecord,
+        _ctx: Context,
+    ) -> Result<(), SignalProtocolError> {
+        self.signed_pre_keys
+            .insert(signed_prekey_id, record.serialize()?);
+        Ok(())
+    }
+}
+
+#[async_trait(?Send)]
+impl SessionStore for VolatileConfigStore {
+    async fn load_session(
+        &self,
+        address: &ProtocolAddress,
+        _ctx: Context,
+    ) -> Result<Option<SessionRecord>, SignalProtocolError> {
+        let db = self.sessions.try_read().expect("poisoned mutex");
+        let key = self.session_key(address);
+        let buf = db.get(&key);
+
+        buf.map(|buf| SessionRecord::deserialize(&buf)).transpose()
+    }
+
+    async fn store_session(
+        &mut self,
+        address: &ProtocolAddress,
+        record: &SessionRecord,
+        _ctx: Context,
+    ) -> Result<(), SignalProtocolError> {
+        let key = self.session_key(address);
+        self.sessions
+            .try_write()
+            .expect("poisoned mutex")
+            .insert(key, record.serialize()?);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SessionStoreExt for VolatileConfigStore {
+    async fn get_sub_device_sessions(&self, name: &str) -> Result<Vec<u32>, SignalProtocolError> {
+        let session_prefix = self.session_prefix(name);
+        log::info!("get_sub_device_sessions: session_prefix={}", session_prefix);
+        let session_ids: Vec<u32> = self
+            .sessions
+            .read()
+            .expect("poisoned mutex")
+            .keys()
+            .filter_map(|key| {
+                let device_id = key.strip_prefix(&session_prefix)?;
+                device_id.parse().ok()
+            })
+            .collect();
+        Ok(session_ids)
+    }
+
+    async fn delete_session(&self, address: &ProtocolAddress) -> Result<(), SignalProtocolError> {
+        let key = self.session_key(address);
+        trace!("deleting session with key: {}", key);
+        self.sessions
+            .try_write()
+            .expect("poisoned mutex")
+            .remove(&key);
+        Ok(())
+    }
+
+    async fn delete_all_sessions(&self, _name: &str) -> Result<usize, SignalProtocolError> {
+        let mut sessions = self.sessions.try_write().expect("poisoned mutex");
+        let len = sessions.len();
+        sessions.clear();
+        Ok(len)
+    }
+}
+
+#[async_trait(?Send)]
+impl IdentityKeyStore for VolatileConfigStore {
+    async fn get_identity_key_pair(
+        &self,
+        _ctx: Context,
+    ) -> Result<IdentityKeyPair, SignalProtocolError> {
+        trace!("getting identity_key_pair");
+        let state = self.load_state().map_err(|e| {
+            SignalProtocolError::InvalidState("failed to load presage state", e.to_string())
+        })?;
+        Ok(IdentityKeyPair::new(
+            IdentityKey::new(state.public_key),
+            state.private_key,
+        ))
+    }
+
+    async fn get_local_registration_id(&self, _ctx: Context) -> Result<u32, SignalProtocolError> {
+        let state = self.load_state().map_err(|e| {
+            SignalProtocolError::InvalidState("failed to load presage state", e.to_string())
+        })?;
+        Ok(state.registration_id)
+    }
+
+    async fn save_identity(
+        &mut self,
+        address: &ProtocolAddress,
+        identity_key: &IdentityKey,
+        _ctx: Context,
+    ) -> Result<bool, SignalProtocolError> {
+        self.identities
+            .try_write()
+            .expect("poisoned mutex")
+            .insert(address.clone(), identity_key.serialize().to_vec());
+        Ok(false)
+    }
+
+    async fn is_trusted_identity(
+        &self,
+        address: &ProtocolAddress,
+        identity_key: &IdentityKey,
+        _direction: Direction,
+        _ctx: Context,
+    ) -> Result<bool, SignalProtocolError> {
+        match self
+            .identities
+            .try_read()
+            .expect("poisoned mutex")
+            .get(address)
+        {
+            None => {
+                // when we encounter a new identity, we trust it by default
+                warn!("trusting new identity {:?}", address);
+                Ok(true)
+            }
+            Some(contents) => Ok(&IdentityKey::decode(&contents)? == identity_key),
+        }
+    }
+
+    async fn get_identity(
+        &self,
+        address: &ProtocolAddress,
+        _ctx: Context,
+    ) -> Result<Option<IdentityKey>, SignalProtocolError> {
+        let db = self.identities.try_read().expect("poisoned mutex");
+        let buf = db.get(address);
+        Ok(buf.map(|ref b| IdentityKey::decode(b).unwrap()))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod manager;
 
 #[cfg(feature = "sled-store")]
 pub use config::sled::SledConfigStore;
+pub use config::volatile::VolatileConfigStore;
 
 pub use config::ConfigStore;
 pub use errors::Error;


### PR DESCRIPTION
This can be useful when you don't want any keys or secret data persisted anywhere, the downside being that all data is lost when you drop the instance of the config store (like when the process exits/dies).

Note: the `VolatileConfigStore` doesn't store contacts.

This is mostly tailored to the use-case of @Philipp-Sc described in #50.