### PR TITLE
More generic way of linking device

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0"
 sled = { version = "0.34", optional = true }
-qr2term = "0.2.2"
+qr2term = { version = "0.2.2", optional = true}
 
 [dev-dependencies]
 # for tests
@@ -43,8 +43,9 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "io-std", "i
 url = "2.2.2"
 
 [features]
-default = ["sled-store"]
+default = ["sled-store", "qr2term"]
 quirks = []
+qr-to-term = ["qr2term"]
 sled-store = ["sled"]
 
 #[patch."https://github.com/whisperfish/libsignal-service-rs.git"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "io-std", "i
 url = "2.2.2"
 
 [features]
-default = ["sled-store", "qr2term"]
+default = ["sled-store", "qr-to-term"]
 quirks = []
 qr-to-term = ["qr2term"]
 sled-store = ["sled"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -39,8 +39,8 @@ pub enum Error {
     ProvisioningError(#[from] libsignal_service::provisioning::ProvisioningError),
     #[error("no provisioning message received")]
     NoProvisioningMessageReceived,
-    #[error("qr code error: {0}")]
-    QrCodeError(qr2term::QrError),
+    #[error("qr code error")]
+    LinkError,
     #[error("missing key {0} in config DB")]
     MissingKeyError(Cow<'static, str>),
     #[error("receiving pipe was interrupted")]


### PR DESCRIPTION
Currently linking a device prints the corresponding QR code into the terminal. This is not really usefull for e.g. graphical clients. This PR makes the linking more generic by providing a callback function that is called with the URL to link with.

This has one disadvantage that error handling is a little bit worse as one cannot exactly identify the type of the error, I therefore just created a unparametrized `LinkError` that is given if the callback returns an error.

I also made the `qr2term` package a optional but default feature so that it can be disabled for graphical applications.