### PR TITLE
SecretVolatileConfigStore added

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "io-std", "i
 qr2term = { version = "0.2.2" }
 
 [features]
-default = ["sled-store","volatile-config-store","secret-volatile-config-store"]
+default = ["sled-store","secret-volatile-config-store"]
 quirks = []
 sled-store = ["sled"]
 secret-volatile-config-store = ["libsodium-sys","secrets"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ serde_json = "1.0"
 thiserror = "1.0"
 sled = { version = "0.34", optional = true }
 url = "2.2.2"
-secrets = { git = "https://github.com/stouset/secrets", optional = true }
+libsodium-sys = { version = "0.2.7", optional = true }
+secrets = { version = "1.2.0", features = ["use-libsodium-sys"], optional = true }
 # fedora: sudo dnf install libsodium-devel
 
 [dev-dependencies]
@@ -48,7 +49,7 @@ qr2term = { version = "0.2.2" }
 default = ["sled-store","volatile","secret-volatile"]
 quirks = []
 sled-store = ["sled"]
-secret-volatile = ["secrets"]
+secret-volatile = ["libsodium-sys","secrets"]
 volatile = []
 
 #[patch."https://github.com/whisperfish/libsignal-service-rs.git"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ serde_json = "1.0"
 thiserror = "1.0"
 sled = { version = "0.34", optional = true }
 url = "2.2.2"
+secrets = { git = "https://github.com/stouset/secrets", optional = true }
+# fedora: sudo dnf install libsodium-devel
 
 [dev-dependencies]
 # for tests
@@ -43,9 +45,11 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "io-std", "i
 qr2term = { version = "0.2.2" }
 
 [features]
-default = ["sled-store"]
+default = ["sled-store","volatile","secret-volatile"]
 quirks = []
 sled-store = ["sled"]
+secret-volatile = ["secrets"]
+volatile = []
 
 #[patch."https://github.com/whisperfish/libsignal-service-rs.git"]
 #libsignal-service = { path = "../libsignal-service-rs/libsignal-service" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,11 +46,11 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "io-std", "i
 qr2term = { version = "0.2.2" }
 
 [features]
-default = ["sled-store","volatile","secret-volatile"]
+default = ["sled-store","volatile-config-store","secret-volatile-config-store"]
 quirks = []
 sled-store = ["sled"]
-secret-volatile = ["libsodium-sys","secrets"]
-volatile = []
+secret-volatile-config-store = ["libsodium-sys","secrets"]
+volatile-config-store = []
 
 #[patch."https://github.com/whisperfish/libsignal-service-rs.git"]
 #libsignal-service = { path = "../libsignal-service-rs/libsignal-service" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ sled = { version = "0.34", optional = true }
 url = "2.2.2"
 libsodium-sys = { version = "0.2.7", optional = true }
 secrets = { version = "1.2.0", features = ["use-libsodium-sys"], optional = true }
-# fedora: sudo dnf install libsodium-devel
 
 [dev-dependencies]
 # for tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "io-std", "i
 qr2term = { version = "0.2.2" }
 
 [features]
-default = ["sled-store","secret-volatile-config-store"]
+default = ["sled-config-store","secret-volatile-config-store"]
 quirks = []
-sled-store = ["sled"]
+sled-config-store = ["sled"]
 secret-volatile-config-store = ["libsodium-sys","secrets"]
 volatile-config-store = []
 

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -15,7 +15,7 @@ use presage::{
         Contact, GroupMasterKey, SignalServers,
     },
     prelude::{phonenumber::PhoneNumber, ServiceAddress, Uuid},
-    ConfigStore, Manager, RegistrationOptions, SledConfigStore, VolatileConfigStore, SecretVolatileConfigStore,
+    ConfigStore, Manager, RegistrationOptions, SledConfigStore, /*VolatileConfigStore,*/ SecretVolatileConfigStore,
 };
 use structopt::StructOpt;
 use tempfile::Builder;
@@ -24,7 +24,6 @@ use tokio::{
     io::{self, AsyncBufReadExt, BufReader},
 };
 use url::Url;
-use futures::FutureExt;
 
 #[derive(StructOpt)]
 #[structopt(about = "a basic signal CLI to try things out")]

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -6,17 +6,13 @@ use directories::ProjectDirs;
 use env_logger::Env;
 use futures::{channel::oneshot, future, pin_mut, StreamExt};
 use log::{debug, info};
-use presage::{
-    prelude::{
-        content::{
-            Content, ContentBody, DataMessage, GroupContext, GroupContextV2, GroupType, SyncMessage,
-        },
-        proto::sync_message::Sent,
-        Contact, GroupMasterKey, SignalServers,
+use presage::{prelude::{
+    content::{
+        Content, ContentBody, DataMessage, GroupContext, GroupContextV2, GroupType, SyncMessage,
     },
-    prelude::{phonenumber::PhoneNumber, ServiceAddress, Uuid},
-    ConfigStore, Manager, RegistrationOptions, SledConfigStore, /*VolatileConfigStore,*/ SecretVolatileConfigStore,
-};
+    proto::sync_message::Sent,
+    Contact, GroupMasterKey, SignalServers,
+}, prelude::{phonenumber::PhoneNumber, ServiceAddress, Uuid}, ConfigStore, Manager, RegistrationOptions, SledConfigStore, SecretVolatileConfigStore, Registered};
 use structopt::StructOpt;
 use tempfile::Builder;
 use tokio::{
@@ -157,6 +153,113 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
+async fn send<C: ConfigStore>(msg: &str, uuid: &Uuid, manager: &Manager<C,Registered>) -> anyhow::Result<()> {
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_millis() as u64;
+
+    let message = ContentBody::DataMessage(DataMessage {
+        body: Some(msg.to_string()),
+        timestamp: Some(timestamp),
+        ..Default::default()
+    });
+
+    manager.send_message(*uuid, message, timestamp).await?;
+    Ok(())
+}
+
+async fn receive<C: ConfigStore>(manager: &Manager<C,Registered>) -> anyhow::Result<()> {
+    let attachments_tmp_dir = Builder::new().prefix("presage-attachments").tempdir()?;
+    info!(
+                                    "attachments will be stored in {}",
+                                    attachments_tmp_dir.path().display()
+                                );
+
+    let messages = manager
+        .clone()
+        .receive_messages()
+        .await
+        .context("failed to initialize messages stream")?;
+    pin_mut!(messages);
+    while let Some(Content { metadata, body }) = messages.next().await {
+        match body {
+            ContentBody::DataMessage(message)
+            | ContentBody::SynchronizeMessage(SyncMessage {
+                                                  sent:
+                                                  Some(Sent {
+                                                           message: Some(message),
+                                                           ..
+                                                       }),
+                                                  ..
+                                              }) => {
+                if let Some(quote) = &message.quote {
+                    println!(
+                        "Quote from {:?}: > {:?} / {}",
+                        metadata.sender,
+                        quote,
+                        message.body(),
+                    );
+                } else if let Some(reaction) = message.reaction {
+                    println!(
+                        "Reaction to message sent at {:?}: {:?}",
+                        reaction.target_sent_timestamp, reaction.emoji,
+                    )
+                } else if let Some(group_context) = message.group_v2 {
+                    let group_changes = manager.decrypt_group_context(group_context)?;
+                    println!("Group change: {:?}", group_changes);
+                } else {
+                    println!("Message from {:?}: {:?}", metadata, message);
+                    // fetch the groups v2 info here, just for testing purposes
+                    if let Some(group_v2) = message.group_v2 {
+                        let master_key = GroupMasterKey::new(
+                            group_v2.master_key.unwrap().try_into().unwrap(),
+                        );
+                        let group = manager.get_group_v2(master_key).await?;
+                        println!("Group v2: {:?}", group.title);
+                    }
+                }
+
+                for attachment_pointer in message.attachments {
+                    let attachment_data =
+                        manager.get_attachment(&attachment_pointer).await?;
+                    let extensions = mime_guess::get_mime_extensions_str(
+                        attachment_pointer
+                            .content_type
+                            .as_deref()
+                            .unwrap_or("application/octet-stream"),
+                    );
+                    let extension = extensions.and_then(|e| e.first()).unwrap_or(&"bin");
+                    let file_path = attachments_tmp_dir.path().join(format!(
+                        "presage-{}.{}",
+                        Local::now().format("%Y-%m-%d-%H-%M-%s"),
+                        extension
+                    ));
+                    fs::write(&file_path, &attachment_data).await?;
+                    info!(
+                                "saved received attachment from {} to {}",
+                                metadata.sender,
+                                file_path.display()
+                            );
+                }
+            }
+            ContentBody::SynchronizeMessage(m) => {
+                eprintln!("Unhandled sync message: {:?}", m);
+            }
+            ContentBody::TypingMessage(_) => {
+                println!("{:?} is typing", metadata.sender);
+            }
+            ContentBody::CallMessage(_) => {
+                println!("{:?} is calling!", metadata.sender);
+            }
+            ContentBody::ReceiptMessage(_) => {
+                println!("Got read receipt from: {:?}", metadata.sender);
+            }
+        }
+    }
+    Ok(())
+}
+
 async fn run<C: ConfigStore>(subcommand: Subcommand, config_store: C) -> anyhow::Result<()> {
     match subcommand {
         Subcommand::Register {
@@ -217,114 +320,15 @@ async fn run<C: ConfigStore>(subcommand: Subcommand, config_store: C) -> anyhow:
 
                     match follow_up_command.as_ref() {
                         "Send" => {
-                            let timestamp = std::time::SystemTime::now()
-                                .duration_since(UNIX_EPOCH)
-                                .expect("Time went backwards")
-                                .as_millis() as u64;
-
-                            let message = ContentBody::DataMessage(DataMessage {
-                                body: Some("Hello World!".to_string()),
-                                timestamp: Some(timestamp),
-                                ..Default::default()
-                            });
-
-                            manager.send_message(uuid, message, timestamp).await?;
+                            send("Hello World",&uuid,&manager).await?;
                         },
                         "Receive" => {
-                            let attachments_tmp_dir = Builder::new().prefix("presage-attachments").tempdir()?;
-                            info!(
-                                    "attachments will be stored in {}",
-                                    attachments_tmp_dir.path().display()
-                                );
-
-                            let messages = manager
-                                .clone()
-                                .receive_messages()
-                                .await
-                                .context("failed to initialize messages stream")?;
-                            pin_mut!(messages);
-                            while let Some(Content { metadata, body }) = messages.next().await {
-                                match body {
-                                    ContentBody::DataMessage(message)
-                                    | ContentBody::SynchronizeMessage(SyncMessage {
-                                                                          sent:
-                                                                          Some(Sent {
-                                                                                   message: Some(message),
-                                                                                   ..
-                                                                               }),
-                                                                          ..
-                                                                      }) => {
-                                        if let Some(quote) = &message.quote {
-                                            println!(
-                                                "Quote from {:?}: > {:?} / {}",
-                                                metadata.sender,
-                                                quote,
-                                                message.body(),
-                                            );
-                                        } else if let Some(reaction) = message.reaction {
-                                            println!(
-                                                "Reaction to message sent at {:?}: {:?}",
-                                                reaction.target_sent_timestamp, reaction.emoji,
-                                            )
-                                        } else if let Some(group_context) = message.group_v2 {
-                                            let group_changes = manager.decrypt_group_context(group_context)?;
-                                            println!("Group change: {:?}", group_changes);
-                                        } else {
-                                            println!("Message from {:?}: {:?}", metadata, message);
-                                            // fetch the groups v2 info here, just for testing purposes
-                                            if let Some(group_v2) = message.group_v2 {
-                                                let master_key = GroupMasterKey::new(
-                                                    group_v2.master_key.unwrap().try_into().unwrap(),
-                                                );
-                                                let group = manager.get_group_v2(master_key).await?;
-                                                println!("Group v2: {:?}", group.title);
-                                            }
-                                        }
-
-                                        for attachment_pointer in message.attachments {
-                                            let attachment_data =
-                                                manager.get_attachment(&attachment_pointer).await?;
-                                            let extensions = mime_guess::get_mime_extensions_str(
-                                                attachment_pointer
-                                                    .content_type
-                                                    .as_deref()
-                                                    .unwrap_or("application/octet-stream"),
-                                            );
-                                            let extension = extensions.and_then(|e| e.first()).unwrap_or(&"bin");
-                                            let file_path = attachments_tmp_dir.path().join(format!(
-                                                "presage-{}.{}",
-                                                Local::now().format("%Y-%m-%d-%H-%M-%s"),
-                                                extension
-                                            ));
-                                            fs::write(&file_path, &attachment_data).await?;
-                                            info!(
-                                "saved received attachment from {} to {}",
-                                metadata.sender,
-                                file_path.display()
-                            );
-                                        }
-                                    }
-                                    ContentBody::SynchronizeMessage(m) => {
-                                        eprintln!("Unhandled sync message: {:?}", m);
-                                    }
-                                    ContentBody::TypingMessage(_) => {
-                                        println!("{:?} is typing", metadata.sender);
-                                    }
-                                    ContentBody::CallMessage(_) => {
-                                        println!("{:?} is calling!", metadata.sender);
-                                    }
-                                    ContentBody::ReceiptMessage(_) => {
-                                        println!("Got read receipt from: {:?}", metadata.sender);
-                                    }
-                                }
-                            }
+                            receive(&manager).await?;
                         },
                         _ => {
 
                         }
                     };
-
-
                 },
                 (Err(err),_) => {
                     println!("{:?}",err);
@@ -332,110 +336,12 @@ async fn run<C: ConfigStore>(subcommand: Subcommand, config_store: C) -> anyhow:
             };
         }
         Subcommand::Receive => {
-            let attachments_tmp_dir = Builder::new().prefix("presage-attachments").tempdir()?;
-            info!(
-                "attachments will be stored in {}",
-                attachments_tmp_dir.path().display()
-            );
-
             let manager = Manager::load_registered(config_store)?;
-            let messages = manager
-                .clone()
-                .receive_messages()
-                .await
-                .context("failed to initialize messages stream")?;
-            pin_mut!(messages);
-            while let Some(Content { metadata, body }) = messages.next().await {
-                match body {
-                    ContentBody::DataMessage(message)
-                    | ContentBody::SynchronizeMessage(SyncMessage {
-                        sent:
-                            Some(Sent {
-                                message: Some(message),
-                                ..
-                            }),
-                        ..
-                    }) => {
-                        if let Some(quote) = &message.quote {
-                            println!(
-                                "Quote from {:?}: > {:?} / {}",
-                                metadata.sender,
-                                quote,
-                                message.body(),
-                            );
-                        } else if let Some(reaction) = message.reaction {
-                            println!(
-                                "Reaction to message sent at {:?}: {:?}",
-                                reaction.target_sent_timestamp, reaction.emoji,
-                            )
-                        } else if let Some(group_context) = message.group_v2 {
-                            let group_changes = manager.decrypt_group_context(group_context)?;
-                            println!("Group change: {:?}", group_changes);
-                        } else {
-                            println!("Message from {:?}: {:?}", metadata, message);
-                            // fetch the groups v2 info here, just for testing purposes
-                            if let Some(group_v2) = message.group_v2 {
-                                let master_key = GroupMasterKey::new(
-                                    group_v2.master_key.unwrap().try_into().unwrap(),
-                                );
-                                let group = manager.get_group_v2(master_key).await?;
-                                println!("Group v2: {:?}", group.title);
-                            }
-                        }
-
-                        for attachment_pointer in message.attachments {
-                            let attachment_data =
-                                manager.get_attachment(&attachment_pointer).await?;
-                            let extensions = mime_guess::get_mime_extensions_str(
-                                attachment_pointer
-                                    .content_type
-                                    .as_deref()
-                                    .unwrap_or("application/octet-stream"),
-                            );
-                            let extension = extensions.and_then(|e| e.first()).unwrap_or(&"bin");
-                            let file_path = attachments_tmp_dir.path().join(format!(
-                                "presage-{}.{}",
-                                Local::now().format("%Y-%m-%d-%H-%M-%s"),
-                                extension
-                            ));
-                            fs::write(&file_path, &attachment_data).await?;
-                            info!(
-                                "saved received attachment from {} to {}",
-                                metadata.sender,
-                                file_path.display()
-                            );
-                        }
-                    }
-                    ContentBody::SynchronizeMessage(m) => {
-                        eprintln!("Unhandled sync message: {:?}", m);
-                    }
-                    ContentBody::TypingMessage(_) => {
-                        println!("{:?} is typing", metadata.sender);
-                    }
-                    ContentBody::CallMessage(_) => {
-                        println!("{:?} is calling!", metadata.sender);
-                    }
-                    ContentBody::ReceiptMessage(_) => {
-                        println!("Got read receipt from: {:?}", metadata.sender);
-                    }
-                }
-            }
+            receive(&manager).await?;
         }
         Subcommand::Send { uuid, message } => {
             let manager = Manager::load_registered(config_store)?;
-
-            let timestamp = std::time::SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("Time went backwards")
-                .as_millis() as u64;
-
-            let message = ContentBody::DataMessage(DataMessage {
-                body: Some(message),
-                timestamp: Some(timestamp),
-                ..Default::default()
-            });
-
-            manager.send_message(uuid, message, timestamp).await?;
+            send(&message,&uuid,&manager).await?;
         }
         Subcommand::SendToGroup {
             recipients,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,7 +8,7 @@ use libsignal_service::{
 
 use crate::{manager::Registered, Error};
 
-#[cfg(feature = "sled-store")]
+#[cfg(feature = "sled-config-store")]
 pub mod sled;
 
 #[cfg(feature = "volatile-config-store")]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,7 +11,11 @@ use crate::{manager::Registered, Error};
 #[cfg(feature = "sled-store")]
 pub mod sled;
 
+#[cfg(feature = "volatile")]
 pub mod volatile;
+
+#[cfg(feature = "secret-volatile")]
+pub mod secret_volatile;
 
 pub trait ConfigStore:
     PreKeyStore

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,10 +11,10 @@ use crate::{manager::Registered, Error};
 #[cfg(feature = "sled-store")]
 pub mod sled;
 
-#[cfg(feature = "volatile")]
+#[cfg(feature = "volatile-config-store")]
 pub mod volatile;
 
-#[cfg(feature = "secret-volatile")]
+#[cfg(feature = "secret-volatile-config-store")]
 pub mod secret_volatile;
 
 pub trait ConfigStore:

--- a/src/config/secret_volatile.rs
+++ b/src/config/secret_volatile.rs
@@ -1,3 +1,4 @@
+
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock, Mutex},
@@ -26,7 +27,7 @@ pub struct SecretVolatileConfigStore {
     // `Cell<u8>` cannot be shared between threads safely (part of SecretBox/SecretVec)
     // - therefore wrapped within a Mutex
     // - to be able to derive the Clone trait Arc is needed
-    // - Option enum to derive derive the Default trait
+    // - Option enum to derive the Default trait
     pre_keys_offset_id: Arc<Mutex<Option<SecretBox<u32>>>>,
     next_signed_pre_key_id: Arc<Mutex<Option<SecretBox<u32>>>>,
 

--- a/src/config/secret_volatile.rs
+++ b/src/config/secret_volatile.rs
@@ -1,0 +1,329 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock, Mutex},
+};
+
+use async_trait::async_trait;
+use libsignal_service::{
+    models::Contact,
+    prelude::{
+        protocol::{
+            Context, Direction, IdentityKey, IdentityKeyPair, IdentityKeyStore, PreKeyRecord,
+            PreKeyStore, ProtocolAddress, SessionRecord, SessionStore, SessionStoreExt,
+            SignalProtocolError, SignedPreKeyRecord, SignedPreKeyStore,
+        },
+        Uuid,
+    },
+};
+use log::{trace, warn};
+use secrets::{SecretBox, SecretVec};
+
+use super::{ConfigStore, ContactsStore, StateStore};
+use crate::{manager::Registered, Error};
+
+#[derive(Default, Debug, Clone)]
+pub struct SecretVolatileConfigStore {
+    // `Cell<u8>` cannot be shared between threads safely (part of SecretBox/SecretVec)
+    // - therefore wrapped within a Mutex
+    // - to be able to derive the Clone trait Arc is needed
+    // - Option enum to derive derive the Default trait
+    pre_keys_offset_id: Arc<Mutex<Option<SecretBox<u32>>>>,
+    next_signed_pre_key_id: Arc<Mutex<Option<SecretBox<u32>>>>,
+
+    pre_keys: Arc<RwLock<HashMap<u32, Mutex<SecretVec<u8>>>>>,
+    signed_pre_keys: Arc<RwLock<HashMap<u32, Mutex<SecretVec<u8>>>>>,
+
+    // XXX: we need interior mutability + Sync until we fix the trait definition to use &mut self in libsignal-service
+    sessions: Arc<RwLock<HashMap<String, Mutex<SecretVec<u8>>>>>,
+
+    identities: Arc<RwLock<HashMap<ProtocolAddress, Mutex<SecretVec<u8>>>>>,
+    registration: Arc<RwLock<Option<Mutex<SecretVec<u8>>>>>,
+}
+// todo: to erase or zero out secrets passed into the secret store upstream refactoring is necessary,
+// parameters for example `id` for `set_pre_keys_offset_id` must be passed as &mut for the secrets crate to zero out the value.
+
+impl SecretVolatileConfigStore {
+    fn session_key(&self, addr: &ProtocolAddress) -> String {
+        format!("session-{}", addr)
+    }
+
+    fn session_prefix(&self, name: &str) -> String {
+        format!("session-{}.", name)
+    }
+}
+
+impl StateStore<Registered> for SecretVolatileConfigStore {
+    fn load_state(&self) -> Result<Registered, Error> {
+        let d = self
+            .registration
+            .try_read()
+            .expect("poisoned mutex");
+        let data = d.as_ref()
+            .ok_or(Error::NotYetRegisteredError)?;
+        let x = serde_json::from_slice(&(*data.try_lock().unwrap()).borrow()).map_err(Error::from); x
+    }
+
+    fn save_state(&mut self, state: &Registered) -> Result<(), Error> {
+        let mut data = serde_json::to_vec(state)?;
+        self.registration = Arc::new(RwLock::new(Some(Mutex::new(SecretVec::from(&mut data[..])))));
+        Ok(())
+    }
+}
+
+impl ConfigStore for SecretVolatileConfigStore {
+    fn pre_keys_offset_id(&self) -> Result<u32, Error> {
+        let d = self.pre_keys_offset_id
+            .try_lock()
+            .expect("poisoned mutex");
+        match d.as_ref() {
+            None => Ok(0u32),
+            Some(s) => Ok(*s.borrow()),
+        }
+    }
+
+    fn set_pre_keys_offset_id(&mut self, id: u32) -> Result<(), Error> {
+        self.pre_keys_offset_id = Arc::new(Mutex::new(Some(SecretBox::<u32>::new(|s| *s=id))));
+        Ok(())
+    }
+
+    fn next_signed_pre_key_id(&self) -> Result<u32, Error> {
+        let d = self.next_signed_pre_key_id
+            .try_lock()
+            .expect("poisoned mutex");
+        match d.as_ref() {
+            None => Ok(0u32),
+            Some(s) => Ok(*s.borrow()),
+        }
+    }
+
+    fn set_next_signed_pre_key_id(&mut self, id: u32) -> Result<(), Error> {
+        self.next_signed_pre_key_id = Arc::new(Mutex::new(Some(SecretBox::<u32>::new(|s| *s=id))));
+        Ok(())
+    }
+}
+
+impl ContactsStore for SecretVolatileConfigStore {
+    fn save_contacts(&mut self, _: impl Iterator<Item = Contact>) -> Result<(), Error> {
+        warn!("contacts are not saved when using volatile storage.");
+        Ok(())
+    }
+
+    fn contacts(&self) -> Result<Vec<Contact>, Error> {
+        warn!("contacts are not saved when using volatile storage.");
+        Ok(vec![])
+    }
+
+    fn contact_by_id(&self, _: Uuid) -> Result<Option<Contact>, Error> {
+        warn!("contacts are not saved when using volatile storage.");
+        Ok(None)
+    }
+}
+
+#[async_trait(?Send)]
+impl PreKeyStore for SecretVolatileConfigStore {
+    async fn get_pre_key(
+        &self,
+        prekey_id: u32,
+        _ctx: Context,
+    ) -> Result<PreKeyRecord, SignalProtocolError> {
+        let buf = self
+            .pre_keys
+            .try_read()
+            .expect("poisoned mutex");
+        let b = buf
+            .get(&prekey_id)
+            .ok_or(SignalProtocolError::InvalidPreKeyId)?;
+        let x = PreKeyRecord::deserialize(&(*b.try_lock().unwrap()).borrow()); x
+    }
+
+    async fn save_pre_key(
+        &mut self,
+        prekey_id: u32,
+        record: &PreKeyRecord,
+        _ctx: Context,
+    ) -> Result<(), SignalProtocolError> {
+        self.pre_keys
+            .try_write()
+            .expect("poisoned mutex")
+            .insert(prekey_id, Mutex::new(SecretVec::from(&mut record.serialize()?[..])));
+        Ok(())
+    }
+
+    async fn remove_pre_key(
+        &mut self,
+        prekey_id: u32,
+        _ctx: Context,
+    ) -> Result<(), SignalProtocolError> {
+        self.pre_keys
+            .try_write()
+            .expect("poisoned mutex")
+            .remove(&prekey_id);
+        Ok(())
+    }
+}
+
+#[async_trait(?Send)]
+impl SignedPreKeyStore for SecretVolatileConfigStore {
+    async fn get_signed_pre_key(
+        &self,
+        signed_prekey_id: u32,
+        _ctx: Context,
+    ) -> Result<SignedPreKeyRecord, SignalProtocolError> {
+        let buf = self
+            .signed_pre_keys
+            .try_write()
+            .expect("poisoned mutex");
+        let b = buf
+            .get(&signed_prekey_id)
+            .ok_or(SignalProtocolError::InvalidSignedPreKeyId)?;
+        let x = SignedPreKeyRecord::deserialize(&(*b.try_lock().unwrap()).borrow()); x
+    }
+
+    async fn save_signed_pre_key(
+        &mut self,
+        signed_prekey_id: u32,
+        record: &SignedPreKeyRecord,
+        _ctx: Context,
+    ) -> Result<(), SignalProtocolError> {
+        self.signed_pre_keys
+            .try_write()
+            .expect("poisoned mutex")
+            .insert(signed_prekey_id, Mutex::new(SecretVec::from(&mut record.serialize()?[..])));
+        Ok(())
+    }
+}
+
+#[async_trait(?Send)]
+impl SessionStore for SecretVolatileConfigStore {
+    async fn load_session(
+        &self,
+        address: &ProtocolAddress,
+        _ctx: Context,
+    ) -> Result<Option<SessionRecord>, SignalProtocolError> {
+        let db = self.sessions.try_read().expect("poisoned mutex");
+        let key = self.session_key(address);
+        let buf = db.get(&key);
+
+        buf.map(|buf| SessionRecord::deserialize(&(*buf.try_lock().unwrap()).borrow())).transpose()
+    }
+
+    async fn store_session(
+        &mut self,
+        address: &ProtocolAddress,
+        record: &SessionRecord,
+        _ctx: Context,
+    ) -> Result<(), SignalProtocolError> {
+        let key = self.session_key(address);
+        let mut data =  record.serialize()?;
+        self.sessions
+            .try_write()
+            .expect("poisoned mutex")
+            .insert(key, Mutex::new(SecretVec::from(&mut data[..])));
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SessionStoreExt for SecretVolatileConfigStore {
+    async fn get_sub_device_sessions(&self, name: &str) -> Result<Vec<u32>, SignalProtocolError> {
+        let session_prefix = self.session_prefix(name);
+        log::info!("get_sub_device_sessions: session_prefix={}", session_prefix);
+        let session_ids: Vec<u32> = self
+            .sessions
+            .read()
+            .expect("poisoned mutex")
+            .keys()
+            .filter_map(|key| {
+                let device_id = key.strip_prefix(&session_prefix)?;
+                device_id.parse().ok()
+            })
+            .collect();
+        Ok(session_ids)
+    }
+
+    async fn delete_session(&self, address: &ProtocolAddress) -> Result<(), SignalProtocolError> {
+        let key = self.session_key(address);
+        trace!("deleting session with key: {}", key);
+        self.sessions
+            .try_write()
+            .expect("poisoned mutex")
+            .remove(&key);
+        Ok(())
+    }
+
+    async fn delete_all_sessions(&self, _name: &str) -> Result<usize, SignalProtocolError> {
+        let mut sessions = self.sessions.try_write().expect("poisoned mutex");
+        let len = sessions.len();
+        sessions.clear();
+        Ok(len)
+    }
+}
+
+#[async_trait(?Send)]
+impl IdentityKeyStore for SecretVolatileConfigStore {
+    async fn get_identity_key_pair(
+        &self,
+        _ctx: Context,
+    ) -> Result<IdentityKeyPair, SignalProtocolError> {
+        trace!("getting identity_key_pair");
+        let state = self.load_state().map_err(|e| {
+            SignalProtocolError::InvalidState("failed to load presage state", e.to_string())
+        })?;
+        Ok(IdentityKeyPair::new(
+            IdentityKey::new(state.public_key),
+            state.private_key,
+        ))
+    }
+
+    async fn get_local_registration_id(&self, _ctx: Context) -> Result<u32, SignalProtocolError> {
+        let state = self.load_state().map_err(|e| {
+            SignalProtocolError::InvalidState("failed to load presage state", e.to_string())
+        })?;
+        Ok(state.registration_id)
+    }
+
+    async fn save_identity(
+        &mut self,
+        address: &ProtocolAddress,
+        identity_key: &IdentityKey,
+        _ctx: Context,
+    ) -> Result<bool, SignalProtocolError> {
+        self.identities
+            .try_write()
+            .expect("poisoned mutex")
+            .insert(address.clone(), Mutex::new(SecretVec::from(&mut identity_key.serialize().to_vec()[..])));
+        Ok(false)
+    }
+
+    async fn is_trusted_identity(
+        &self,
+        address: &ProtocolAddress,
+        identity_key: &IdentityKey,
+        _direction: Direction,
+        _ctx: Context,
+    ) -> Result<bool, SignalProtocolError> {
+        match self.identities
+            .try_read()
+            .expect("poisoned mutex").get(address) {
+            None => {
+                // when we encounter a new identity, we trust it by default
+                warn!("trusting new identity {:?}", address);
+                Ok(true)
+            }
+            Some(contents) => Ok(&IdentityKey::decode(&(*contents.try_lock().unwrap()).borrow())? == identity_key),
+        }
+    }
+
+    async fn get_identity(
+        &self,
+        address: &ProtocolAddress,
+        _ctx: Context,
+    ) -> Result<Option<IdentityKey>, SignalProtocolError> {
+        let identities = self.identities
+            .try_write()
+            .expect("poisoned mutex");
+        let buf = identities
+            .get(address);
+        Ok(buf.map(|ref b| IdentityKey::decode(&(*b.try_lock().unwrap()).borrow()).unwrap()))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod manager;
 #[cfg(feature = "sled-store")]
 pub use config::sled::SledConfigStore;
 pub use config::volatile::VolatileConfigStore;
+pub use config::secret_volatile::SecretVolatileConfigStore;
 
 pub use config::ConfigStore;
 pub use errors::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,10 @@ mod manager;
 
 #[cfg(feature = "sled-store")]
 pub use config::sled::SledConfigStore;
+
+#[cfg(feature = "volatile")]
 pub use config::volatile::VolatileConfigStore;
+#[cfg(feature = "secret-volatile")]
 pub use config::secret_volatile::SecretVolatileConfigStore;
 
 pub use config::ConfigStore;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,9 @@ mod manager;
 #[cfg(feature = "sled-store")]
 pub use config::sled::SledConfigStore;
 
-#[cfg(feature = "volatile")]
+#[cfg(feature = "volatile-config-store")]
 pub use config::volatile::VolatileConfigStore;
-#[cfg(feature = "secret-volatile")]
+#[cfg(feature = "secret-volatile-config-store")]
 pub use config::secret_volatile::SecretVolatileConfigStore;
 
 pub use config::ConfigStore;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ mod config;
 mod errors;
 mod manager;
 
-#[cfg(feature = "sled-store")]
+#[cfg(feature = "sled-config-store")]
 pub use config::sled::SledConfigStore;
 
 #[cfg(feature = "volatile-config-store")]


### PR DESCRIPTION
This adds `SecretVolatileConfigStore` using utilities provided by [libsodium](https://download.libsodium.org/doc/memory_management) via the [secrets](https://github.com/stouset/secrets) crate.

To my understanding this only protects the data copied into the store. Any values moving around via `manager.rs` are not protected. 

1) @gferon Does the `manager` contain data that should also be hidden? E.g State: `Registered`?

2) To reduce the exposure further this would require a more thigh integration. 
I.e making sure the data that is passed to the `SecretVolatileConfigStore` is mutable, see `SecretBox` implementation:
```    
# Example: move mutable data into a [`SecretBox`]
///
/// Existing data can be moved into a [`SecretBox`]. When doing so, we
/// make a best-effort attempt to zero out the data in the original
/// location. Any prior copies will be unaffected, so please exercise as
/// much caution as possible when handling data before it can be
/// protected.
```
 