### PR TITLE
Export things needed to create custom ConfigStore

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod manager;
 pub use config::sled::SledConfigStore;
 pub use config::volatile::VolatileConfigStore;
 
-pub use config::ConfigStore;
+pub use config::{ConfigStore, ContactsStore, StateStore};
 pub use errors::Error;
 pub use manager::{Confirmation, Linking, Manager, Registered, Registration, RegistrationOptions};
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -84,12 +84,26 @@ pub struct Registered {
     #[serde(with = "serde_signaling_key")]
     signaling_key: SignalingKey,
     pub device_id: Option<u32>,
-    pub registration_id: u32,
+    pub(crate) registration_id: u32,
     #[serde(with = "serde_private_key")]
-    pub private_key: PrivateKey,
+    pub(crate) private_key: PrivateKey,
     #[serde(with = "serde_public_key")]
-    pub public_key: PublicKey,
+    pub(crate) public_key: PublicKey,
     profile_key: ProfileKey,
+}
+
+impl Registered {
+    pub fn registration_id(&self) -> u32 {
+        self.registration_id
+    }
+
+    pub fn private_key(&self) -> PrivateKey {
+        self.private_key.clone()
+    }
+
+    pub fn public_key(&self) -> PublicKey {
+        self.public_key.clone()
+    }
 }
 
 impl<C: ConfigStore> Manager<C, Registration> {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -84,11 +84,11 @@ pub struct Registered {
     #[serde(with = "serde_signaling_key")]
     signaling_key: SignalingKey,
     pub device_id: Option<u32>,
-    pub(crate) registration_id: u32,
+    pub registration_id: u32,
     #[serde(with = "serde_private_key")]
-    pub(crate) private_key: PrivateKey,
+    pub private_key: PrivateKey,
     #[serde(with = "serde_public_key")]
-    pub(crate) public_key: PublicKey,
+    pub public_key: PublicKey,
     profile_key: ProfileKey,
 }
 


### PR DESCRIPTION
Currently, implementing a custom `ConfigStore` outside of `presage` is not possible, mainly as `ContactsStore` and `StateStore` are not publicly accessible. Futhermore, some data in `Registered` needs to be public to be stored in the `StateStore`. This PR basically just makes all of these needed things public.

I also thought about maybe hiding the exports behind a feature, as most people will probably not need to create their own `ConfigStore`, but having the option is still needed as sometimes the built-in stores may not suffice.

Also note that the CI is currently failing, I did not change anything there so it will probably also fail in this PR.