### PR TITLE
Message storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,12 @@ url = "2.2.2"
 libsodium-sys = { version = "0.2.7", optional = true }
 secrets = { version = "1.2.0", features = ["use-libsodium-sys"], optional = true }
 
+bytes = "1"
+prost = "0.10"
+
+[build-dependencies]
+prost-build = "0.10"
+
 [dev-dependencies]
 # for tests
 quickcheck = "1.0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,33 @@
+use std::io::Result;
+use std::path::Path;
+
+fn main() -> Result<()> {
+    let protobuf = Path::new("src/protobuf").to_owned();
+
+    // Build script does not automagically rerun when a new protobuf file is added.
+    // Directories are checked against mtime, which is platform specific
+    println!("cargo:rerun-if-changed=src/protobuf");
+    // Adding src/proto.rs means an extra `include!` will trigger a rerun. This is on best-effort
+    // basis.
+    println!("cargo:rerun-if-changed=src/proto.rs");
+
+    let input: Vec<_> = protobuf
+        .read_dir()
+        .expect("protobuf directory")
+        .filter_map(|entry| {
+            let entry = entry.expect("readable protobuf directory");
+            let path = entry.path();
+            if Some("proto") == path.extension().and_then(std::ffi::OsStr::to_str) {
+                assert!(path.is_file());
+                println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    prost_build::compile_protos(&input, &[protobuf])?;
+
+    Ok(())
+}

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -8,9 +8,7 @@ use futures::{channel::oneshot, future, pin_mut, StreamExt};
 use log::{debug, info};
 use presage::{
     prelude::{
-        content::{
-            Content, ContentBody, DataMessage, GroupContext, GroupContextV2, GroupType, SyncMessage,
-        },
+        content::{Content, ContentBody, DataMessage, GroupContextV2, SyncMessage},
         proto::sync_message::Sent,
         Contact, GroupMasterKey, SignalServers,
     },
@@ -189,8 +187,7 @@ async fn receive<C: ConfigStore + MessageStore>(
         attachments_tmp_dir.path().display()
     );
 
-    let clone = manager.clone();
-    let messages = clone
+    let messages = manager
         .receive_messages_store()
         .await
         .context("failed to initialize messages stream")?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -46,8 +46,8 @@ pub trait ContactsStore {
     fn contact_by_id(&self, id: Uuid) -> Result<Option<Contact>, Error>;
 }
 
-#[derive(Debug)]
-pub struct MessageIdentity(Uuid, u64);
+#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+pub struct MessageIdentity(pub Uuid, pub u64);
 
 impl TryFrom<&Content> for MessageIdentity {
     type Error = Error;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,7 +2,7 @@ use libsignal_service::{
     models::Contact,
     prelude::{
         protocol::{IdentityKeyStore, PreKeyStore, SessionStoreExt, SignedPreKeyStore},
-        Uuid,
+        Content, Uuid,
     },
 };
 
@@ -43,4 +43,15 @@ pub trait ContactsStore {
     fn save_contacts(&mut self, contacts: impl Iterator<Item = Contact>) -> Result<(), Error>;
     fn contacts(&self) -> Result<Vec<Contact>, Error>;
     fn contact_by_id(&self, id: Uuid) -> Result<Option<Contact>, Error>;
+}
+
+pub trait MessageStore {
+    fn save_message(&mut self, sender: Uuid, timestamp: u64, message: Content)
+        -> Result<(), Error>;
+    fn messages(&self) -> Result<Vec<Content>, Error>;
+    fn message_by_sender_timestamp(
+        &self,
+        sender: Uuid,
+        timestamp: u64,
+    ) -> Result<Option<Content>, Error>;
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,5 @@
 use libsignal_service::{
-    content::ContentBody,
+    content::{ContentBody, Reaction},
     models::Contact,
     prelude::{
         protocol::{IdentityKeyStore, PreKeyStore, SessionStoreExt, SignedPreKeyStore},
@@ -77,6 +77,17 @@ impl TryFrom<&Quote> for MessageIdentity {
         Ok(Self(
             Uuid::parse_str(q.author_uuid.as_ref().ok_or(Error::ContentMissingUuid)?)?,
             q.id.ok_or(Error::ContentMissingUuid)?,
+        ))
+    }
+}
+
+impl TryFrom<&Reaction> for MessageIdentity {
+    type Error = Error;
+
+    fn try_from(r: &Reaction) -> Result<Self, Self::Error> {
+        Ok(Self(
+            Uuid::parse_str(r.target_author_uuid.as_ref().ok_or(Error::ContentMissingUuid)?)?,
+            r.target_sent_timestamp.ok_or(Error::ContentMissingUuid)?,
         ))
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -86,7 +86,11 @@ impl TryFrom<&Reaction> for MessageIdentity {
 
     fn try_from(r: &Reaction) -> Result<Self, Self::Error> {
         Ok(Self(
-            Uuid::parse_str(r.target_author_uuid.as_ref().ok_or(Error::ContentMissingUuid)?)?,
+            Uuid::parse_str(
+                r.target_author_uuid
+                    .as_ref()
+                    .ok_or(Error::ContentMissingUuid)?,
+            )?,
             r.target_sent_timestamp.ok_or(Error::ContentMissingUuid)?,
         ))
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,7 @@ use libsignal_service::{
         protocol::{IdentityKeyStore, PreKeyStore, SessionStoreExt, SignedPreKeyStore},
         Content, Uuid,
     },
+    proto::GroupContextV2,
 };
 
 use crate::{manager::Registered, Error};
@@ -45,13 +46,45 @@ pub trait ContactsStore {
     fn contact_by_id(&self, id: Uuid) -> Result<Option<Contact>, Error>;
 }
 
+#[derive(Debug)]
+pub struct MessageIdentity(Uuid, u64);
+
+impl TryFrom<&Content> for MessageIdentity {
+    type Error = Error;
+    fn try_from(c: &Content) -> Result<Self, <Self as TryFrom<&Content>>::Error> {
+        Ok(Self(
+            c.metadata.sender.uuid.ok_or(Error::ContentMissingUuid)?,
+            c.metadata.timestamp,
+        ))
+    }
+}
+
+// 16 bytes for Uuid, 8 for timestamp
+impl From<[u8; 24]> for MessageIdentity {
+    fn from(bytes: [u8; 24]) -> Self {
+        let bytes_uuid = &bytes[..16];
+        let bytes_timestamp = &bytes[16..];
+        Self(
+            Uuid::from_bytes(bytes_uuid.try_into().unwrap()),
+            u64::from_ne_bytes(bytes_timestamp.try_into().unwrap()),
+        )
+    }
+}
+
+impl From<MessageIdentity> for [u8; 24] {
+    fn from(m: MessageIdentity) -> Self {
+        [m.0.as_bytes() as &[u8], &m.1.to_ne_bytes()]
+            .concat()
+            .try_into()
+            .unwrap()
+    }
+}
+
 pub trait MessageStore {
-    fn save_message(&mut self, sender: Uuid, timestamp: u64, message: Content)
-        -> Result<(), Error>;
+    fn save_message(&mut self, message: Content) -> Result<(), Error>;
     fn messages(&self) -> Result<Vec<Content>, Error>;
-    fn message_by_sender_timestamp(
-        &self,
-        sender: Uuid,
-        timestamp: u64,
-    ) -> Result<Option<Content>, Error>;
+    fn message_by_identity(&self, id: &MessageIdentity) -> Result<Option<Content>, Error>;
+
+    fn messages_by_contact(&self, contact: &Uuid) -> Result<Vec<MessageIdentity>, Error>;
+    fn messages_by_group(&self, group: &GroupContextV2) -> Result<Vec<MessageIdentity>, Error>;
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,7 @@ use libsignal_service::{
         protocol::{IdentityKeyStore, PreKeyStore, SessionStoreExt, SignedPreKeyStore},
         Content, Uuid,
     },
-    proto::GroupContextV2,
+    proto::{data_message::Quote, GroupContextV2},
 };
 
 use crate::{manager::Registered, Error};
@@ -55,6 +55,17 @@ impl TryFrom<&Content> for MessageIdentity {
         Ok(Self(
             c.metadata.sender.uuid.ok_or(Error::ContentMissingUuid)?,
             c.metadata.timestamp,
+        ))
+    }
+}
+
+impl TryFrom<&Quote> for MessageIdentity {
+    type Error = Error;
+
+    fn try_from(q: &Quote) -> Result<Self, Self::Error> {
+        Ok(Self(
+            Uuid::parse_str(q.author_uuid.as_ref().ok_or(Error::ContentMissingUuid)?)?,
+            q.id.ok_or(Error::ContentMissingUuid)?,
         ))
     }
 }

--- a/src/config/secret_volatile.rs
+++ b/src/config/secret_volatile.rs
@@ -19,7 +19,7 @@ use log::{trace, warn};
 use secrets::{SecretBox, SecretVec};
 
 use super::{ConfigStore, ContactsStore, StateStore};
-use crate::{manager::Registered, Error};
+use crate::{manager::Registered, Error, MessageStore};
 
 // - SecretId adds the Default trait to SecretBox<u32>
 #[derive(Debug, Clone)]
@@ -121,6 +121,32 @@ impl ContactsStore for SecretVolatileConfigStore {
 
     fn contact_by_id(&self, _: Uuid) -> Result<Option<Contact>, Error> {
         warn!("contacts are not saved when using volatile storage.");
+        Ok(None)
+    }
+}
+
+impl MessageStore for SecretVolatileConfigStore {
+    fn save_message(
+        &mut self,
+        _sender: Uuid,
+        _timestamp: u64,
+        _message: libsignal_service::prelude::Content,
+    ) -> Result<(), Error> {
+        warn!("messages are not saved when using volatile storage.");
+        Ok(())
+    }
+
+    fn messages(&self) -> Result<Vec<libsignal_service::prelude::Content>, Error> {
+        warn!("messages are not saved when using volatile storage.");
+        Ok(vec![])
+    }
+
+    fn message_by_sender_timestamp(
+        &self,
+        _sender: Uuid,
+        _timestamp: u64,
+    ) -> Result<Option<libsignal_service::prelude::Content>, Error> {
+        warn!("messages are not saved when using volatile storage.");
         Ok(None)
     }
 }

--- a/src/config/secret_volatile.rs
+++ b/src/config/secret_volatile.rs
@@ -20,7 +20,7 @@ use libsignal_service::{
 use log::{trace, warn};
 use secrets::{SecretBox, SecretVec};
 
-use super::{ConfigStore, ContactsStore, MessageIdentity, StateStore, Thread};
+use super::{ConfigStore, ContactsStore, StateStore, Thread};
 use crate::{manager::Registered, Error, MessageStore};
 
 // - SecretId adds the Default trait to SecretBox<u32>
@@ -138,24 +138,16 @@ impl MessageStore for SecretVolatileConfigStore {
         Ok(())
     }
 
-    fn messages(&self) -> Result<Vec<libsignal_service::prelude::Content>, Error> {
-        warn!("messages are not saved when using volatile storage.");
-        Ok(vec![])
-    }
-
-    fn message_by_identity(
+    fn message(
         &self,
-        _id: &MessageIdentity,
+        _thread: &Thread,
+        _timestamp: u64,
     ) -> Result<Option<libsignal_service::prelude::Content>, Error> {
         warn!("messages are not saved when using volatile storage.");
         Ok(None)
     }
 
-    fn messages_by_thread(
-        &self,
-        _thread: &Thread,
-        _from: Option<u64>,
-    ) -> Result<Self::MessagesIter, Error> {
+    fn messages(&self, _thread: &Thread, _from: Option<u64>) -> Result<Self::MessagesIter, Error> {
         warn!("messages are not saved when using volatile storage.");
         Ok(vec![].into_iter())
     }

--- a/src/config/secret_volatile.rs
+++ b/src/config/secret_volatile.rs
@@ -14,6 +14,7 @@ use libsignal_service::{
         },
         Uuid,
     },
+    ServiceAddress,
 };
 use log::{trace, warn};
 use secrets::{SecretBox, SecretVec};
@@ -126,7 +127,11 @@ impl ContactsStore for SecretVolatileConfigStore {
 }
 
 impl MessageStore for SecretVolatileConfigStore {
-    fn save_message(&mut self, _message: libsignal_service::prelude::Content) -> Result<(), Error> {
+    fn save_message(
+        &mut self,
+        _message: libsignal_service::prelude::Content,
+        _: Option<impl Into<ServiceAddress>>,
+    ) -> Result<(), Error> {
         warn!("messages are not saved when using volatile storage.");
         Ok(())
     }

--- a/src/config/secret_volatile.rs
+++ b/src/config/secret_volatile.rs
@@ -12,14 +12,14 @@ use libsignal_service::{
             PreKeyStore, ProtocolAddress, SessionRecord, SessionStore, SessionStoreExt,
             SignalProtocolError, SignedPreKeyRecord, SignedPreKeyStore,
         },
-        Uuid,
+        Content, Uuid,
     },
     ServiceAddress,
 };
 use log::{trace, warn};
 use secrets::{SecretBox, SecretVec};
 
-use super::{ConfigStore, ContactsStore, MessageIdentity, StateStore};
+use super::{ConfigStore, ContactsStore, MessageIdentity, StateStore, Thread};
 use crate::{manager::Registered, Error, MessageStore};
 
 // - SecretId adds the Default trait to SecretBox<u32>
@@ -127,6 +127,7 @@ impl ContactsStore for SecretVolatileConfigStore {
 }
 
 impl MessageStore for SecretVolatileConfigStore {
+    type MessagesIter = std::vec::IntoIter<Content>;
     fn save_message(
         &mut self,
         _message: libsignal_service::prelude::Content,
@@ -149,17 +150,13 @@ impl MessageStore for SecretVolatileConfigStore {
         Ok(None)
     }
 
-    fn messages_by_contact(&self, _contact: &Uuid) -> Result<Vec<MessageIdentity>, Error> {
-        warn!("messages are not saved when using volatile storage.");
-        Ok(vec![])
-    }
-
-    fn messages_by_group(
+    fn messages_by_thread(
         &self,
-        _group: &libsignal_service::proto::GroupContextV2,
-    ) -> Result<Vec<MessageIdentity>, Error> {
+        _thread: &Thread,
+        _from: Option<u64>,
+    ) -> Result<Self::MessagesIter, Error> {
         warn!("messages are not saved when using volatile storage.");
-        Ok(vec![])
+        Ok(vec![].into_iter())
     }
 }
 

--- a/src/config/secret_volatile.rs
+++ b/src/config/secret_volatile.rs
@@ -18,7 +18,7 @@ use libsignal_service::{
 use log::{trace, warn};
 use secrets::{SecretBox, SecretVec};
 
-use super::{ConfigStore, ContactsStore, StateStore};
+use super::{ConfigStore, ContactsStore, MessageIdentity, StateStore};
 use crate::{manager::Registered, Error, MessageStore};
 
 // - SecretId adds the Default trait to SecretBox<u32>
@@ -126,12 +126,7 @@ impl ContactsStore for SecretVolatileConfigStore {
 }
 
 impl MessageStore for SecretVolatileConfigStore {
-    fn save_message(
-        &mut self,
-        _sender: Uuid,
-        _timestamp: u64,
-        _message: libsignal_service::prelude::Content,
-    ) -> Result<(), Error> {
+    fn save_message(&mut self, _message: libsignal_service::prelude::Content) -> Result<(), Error> {
         warn!("messages are not saved when using volatile storage.");
         Ok(())
     }
@@ -141,13 +136,25 @@ impl MessageStore for SecretVolatileConfigStore {
         Ok(vec![])
     }
 
-    fn message_by_sender_timestamp(
+    fn message_by_identity(
         &self,
-        _sender: Uuid,
-        _timestamp: u64,
+        _id: &MessageIdentity,
     ) -> Result<Option<libsignal_service::prelude::Content>, Error> {
         warn!("messages are not saved when using volatile storage.");
         Ok(None)
+    }
+
+    fn messages_by_contact(&self, _contact: &Uuid) -> Result<Vec<MessageIdentity>, Error> {
+        warn!("messages are not saved when using volatile storage.");
+        Ok(vec![])
+    }
+
+    fn messages_by_group(
+        &self,
+        _group: &libsignal_service::proto::GroupContextV2,
+    ) -> Result<Vec<MessageIdentity>, Error> {
+        warn!("messages are not saved when using volatile storage.");
+        Ok(vec![])
     }
 }
 

--- a/src/config/sled.rs
+++ b/src/config/sled.rs
@@ -520,18 +520,13 @@ impl MessageStore for SledConfigStore {
         &self,
         id: &MessageIdentity,
     ) -> Result<Option<libsignal_service::prelude::Content>, Error> {
-        let sender = id.0;
-        let timestamp = id.1;
-
         let tree = self
             .db
             .try_read()
             .expect("poisoned mutex")
             .open_tree(SLED_TREE_MESSAGES)?;
-        let key_sender = sender.as_bytes();
         // Big-Endian needed, otherwise wrong ordering in sled.
-        let key_timestamp = timestamp.to_be_bytes();
-        let key = [&key_sender[..], &key_timestamp[..]].concat();
+        let key: [u8; 24] = id.clone().into();
         let val = tree.get(key)?;
         if let Some(val) = val {
             let proto = ContentProto::decode(&*val)?;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,6 +15,8 @@ pub enum Error {
     ProstError(#[from] prost::DecodeError),
     #[error("data store error: {0}")]
     DbError(#[from] sled::Error),
+    #[error("data store error: {0}")]
+    DbTransactionError(#[from] sled::transaction::TransactionError),
     #[error("error decoding base64 data: {0}")]
     Base64Error(#[from] base64::DecodeError),
     #[error("wrong slice size: {0}")]
@@ -51,4 +53,6 @@ pub enum Error {
     ParseContactError(#[from] ParseContactError),
     #[error("failed to decrypt attachment: {0}")]
     AttachmentCipherError(#[from] libsignal_service::attachment_cipher::AttachmentCipherError),
+    #[error("message is missing a uuid")]
+    ContentMissingUuid,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,6 +11,8 @@ pub enum Error {
     IoError(#[from] std::io::Error),
     #[error("JSON error: {0}")]
     JsonError(#[from] serde_json::Error),
+    #[error("Prost error: {0}")]
+    ProstError(#[from] prost::DecodeError),
     #[error("data store error: {0}")]
     DbError(#[from] sled::Error),
     #[error("error decoding base64 data: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,16 +2,17 @@ mod cache;
 mod config;
 mod errors;
 mod manager;
+mod proto;
 
 #[cfg(feature = "sled-config-store")]
 pub use config::sled::SledConfigStore;
 
-#[cfg(feature = "volatile-config-store")]
-pub use config::volatile::VolatileConfigStore;
 #[cfg(feature = "secret-volatile-config-store")]
 pub use config::secret_volatile::SecretVolatileConfigStore;
+#[cfg(feature = "volatile-config-store")]
+pub use config::volatile::VolatileConfigStore;
 
-pub use config::{ConfigStore, ContactsStore, StateStore};
+pub use config::{ConfigStore, ContactsStore, MessageStore, StateStore};
 pub use errors::Error;
 pub use manager::{Confirmation, Linking, Manager, Registered, Registration, RegistrationOptions};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub use config::secret_volatile::SecretVolatileConfigStore;
 #[cfg(feature = "volatile-config-store")]
 pub use config::volatile::VolatileConfigStore;
 
-pub use config::{ConfigStore, ContactsStore, MessageIdentity, MessageStore, StateStore, Thread};
+pub use config::{ConfigStore, ContactsStore, MessageStore, StateStore, Thread};
 pub use errors::Error;
 pub use manager::{Confirmation, Linking, Manager, Registered, Registration, RegistrationOptions};
 pub use proto::ContentProto;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,10 @@ pub use config::secret_volatile::SecretVolatileConfigStore;
 #[cfg(feature = "volatile-config-store")]
 pub use config::volatile::VolatileConfigStore;
 
-pub use config::{ConfigStore, ContactsStore, MessageStore, StateStore};
+pub use config::{ConfigStore, ContactsStore, MessageIdentity, MessageStore, StateStore};
 pub use errors::Error;
 pub use manager::{Confirmation, Linking, Manager, Registered, Registration, RegistrationOptions};
+pub use proto::ContentProto;
 
 #[deprecated(note = "Please help use improve the prelude module instead")]
 pub use libsignal_service;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub use config::secret_volatile::SecretVolatileConfigStore;
 #[cfg(feature = "volatile-config-store")]
 pub use config::volatile::VolatileConfigStore;
 
-pub use config::{ConfigStore, ContactsStore, MessageIdentity, MessageStore, StateStore};
+pub use config::{ConfigStore, ContactsStore, MessageIdentity, MessageStore, StateStore, Thread};
 pub use errors::Error;
 pub use manager::{Confirmation, Linking, Manager, Registered, Registration, RegistrationOptions};
 pub use proto::ContentProto;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -832,8 +832,9 @@ where
         let mut store = self.config_store.clone();
         Ok(self.receive_messages().await?.map(move |c| {
             if c.metadata.sender.uuid.is_some() {
-                // TODO: Error handling?
-                let _ = store.save_message(c.clone(), None::<ServiceAddress>);
+                if let Err(e) = store.save_message(c.clone(), None::<ServiceAddress>) {
+                    log::error!("Error saving message to store: {}", e);
+                }
             }
             c
         }))

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -833,7 +833,7 @@ where
         Ok(self.receive_messages().await?.map(move |c| {
             if c.metadata.sender.uuid.is_some() {
                 // TODO: Error handling?
-                let _ = store.save_message(c.clone());
+                let _ = store.save_message(c.clone(), None::<ServiceAddress>);
             }
             c
         }))

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -288,7 +288,7 @@ impl<C: ConfigStore> Manager<C, Linking> {
         )
         .await;
 
-        let _ = fut1?;
+        fut1?;
         let (phone_number, device_id, registration_id, uuid, private_key, public_key, profile_key) =
             fut2?;
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -827,9 +827,9 @@ where
     pub async fn receive_messages_store(&self) -> Result<impl Stream<Item = Content> + '_, Error> {
         let mut store = self.config_store.clone();
         Ok(self.receive_messages().await?.map(move |c| {
-            if let Some(sender_uuid) = c.metadata.sender.uuid {
+            if c.metadata.sender.uuid.is_some() {
                 // TODO: Error handling?
-                let _ = store.save_message(sender_uuid, c.metadata.timestamp, c.clone());
+                let _ = store.save_message(c.clone());
             }
             c
         }))

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,0 +1,128 @@
+mod textsecure {
+    include!(concat!(env!("OUT_DIR"), "/textsecure.rs"));
+}
+
+use std::str::FromStr;
+
+use self::textsecure::AddressProto;
+use self::textsecure::MetadataProto;
+use crate::prelude::{PhoneNumber, ServiceAddress};
+use libsignal_service::content::Metadata;
+use libsignal_service::prelude::Content;
+use libsignal_service::prelude::Uuid;
+
+impl AddressProto {
+    pub fn from_service(s: ServiceAddress) -> AddressProto {
+        AddressProto {
+            uuid: s.uuid.map(|u| u.as_bytes().to_vec()),
+            e164: s.e164(),
+        }
+    }
+
+    pub fn into_service(self) -> ServiceAddress {
+        ServiceAddress {
+            uuid: self
+                .uuid
+                .map(|u| Uuid::from_bytes(u.try_into().expect("Proto to have 16 bytes uuid"))),
+            phonenumber: self.e164.and_then(|p| PhoneNumber::from_str(&p).ok()),
+            relay: None,
+        }
+    }
+}
+
+impl MetadataProto {
+    pub fn from_metadata(m: Metadata) -> MetadataProto {
+        MetadataProto {
+            address: Some(AddressProto::from_service(m.sender)),
+            sender_device: m.sender_device.try_into().ok(),
+            timestamp: m.timestamp.try_into().ok(),
+            server_received_timestamp: None,
+            server_delivered_timestamp: None,
+            needs_receipt: Some(m.needs_receipt),
+            server_guid: None,
+            group_id: None,
+            destination_uuid: None,
+        }
+    }
+
+    pub fn into_metadata(self) -> Metadata {
+        Metadata {
+            sender: self
+                .address
+                .map(|a| a.into_service())
+                .unwrap_or_else(|| ServiceAddress {
+                    uuid: None,
+                    phonenumber: None,
+                    relay: None,
+                }),
+            sender_device: self
+                .sender_device
+                .and_then(|m| m.try_into().ok())
+                .unwrap_or_default(),
+            timestamp: self
+                .timestamp
+                .and_then(|m| m.try_into().ok())
+                .unwrap_or_default(),
+            needs_receipt: self.needs_receipt.unwrap_or_default(),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ContentProto {
+    #[prost(message, required, tag = "1")]
+    metadata: MetadataProto,
+    #[prost(message, required, tag = "2")]
+    content: crate::prelude::proto::Content,
+}
+
+impl ContentProto {
+    pub fn from_content(c: Content) -> ContentProto {
+        ContentProto {
+            metadata: MetadataProto::from_metadata(c.metadata),
+            content: c.body.into_proto(),
+        }
+    }
+
+    pub fn into_content(self) -> Content {
+        content_from_proto(self.content, self.metadata.into_metadata())
+            .expect("Content to have at least one type")
+    }
+}
+
+/// TODO: From  libsignal_service
+/// Converts a proto::Content into a public Content, including metadata.
+pub(crate) fn content_from_proto(
+    p: libsignal_service::proto::Content,
+    metadata: Metadata,
+) -> Option<libsignal_service::content::Content> {
+    // The Java version also assumes only one content type at a time.
+    // It's a bit sad that we cannot really match here, we've got no
+    // r#type() method.
+    // Allow the manual map (if let Some -> option.map(||)), because it
+    // reduces the git diff when more types would be added.
+    #[allow(clippy::manual_map)]
+    if let Some(msg) = p.data_message {
+        Some(libsignal_service::content::Content::from_body(
+            msg, metadata,
+        ))
+    } else if let Some(msg) = p.sync_message {
+        Some(libsignal_service::content::Content::from_body(
+            msg, metadata,
+        ))
+    } else if let Some(msg) = p.call_message {
+        Some(libsignal_service::content::Content::from_body(
+            msg, metadata,
+        ))
+    } else if let Some(msg) = p.receipt_message {
+        Some(libsignal_service::content::Content::from_body(
+            msg, metadata,
+        ))
+    } else if let Some(msg) = p.typing_message {
+        Some(libsignal_service::content::Content::from_body(
+            msg, metadata,
+        ))
+    } else {
+        None
+    }
+}

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,3 +1,5 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+
 mod textsecure {
     include!(concat!(env!("OUT_DIR"), "/textsecure.rs"));
 }

--- a/src/protobuf/InternalSerialization.proto
+++ b/src/protobuf/InternalSerialization.proto
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2019 Open Whisper Systems
+ *
+ * Licensed according to the LICENSE file in this repository.
+ */
+syntax = "proto2";
+
+package textsecure;
+
+// Not needed
+// import "SignalService.proto";
+
+option java_package        = "org.whispersystems.signalservice.internal.serialize.protos";
+option java_multiple_files = true;
+
+// Not needed
+// message SignalServiceContentProto {
+//   optional AddressProto  localAddress = 1;
+//   optional MetadataProto metadata     = 2;
+//   oneof data {
+//      signalservice.DataMessage legacyDataMessage = 3;
+//      signalservice.Content     content           = 4;
+//   }
+// }
+
+message SignalServiceEnvelopeProto {
+  optional int32  type                     = 1;
+  optional string sourceUuid               = 2;
+  optional string sourceE164               = 3;
+  optional int32  deviceId                 = 4;
+  optional bytes  legacyMessage            = 5;
+  optional bytes  content                  = 6;
+  optional int64  timestamp                = 7;
+  optional int64  serverReceivedTimestamp  = 8;
+  optional int64  serverDeliveredTimestamp = 9;
+  optional string serverGuid               = 10;
+  optional string destinationUuid          = 11;
+  optional bool   urgent                   = 12 [default = true];
+}
+
+message MetadataProto {
+  optional AddressProto address                  = 1;
+  optional int32        senderDevice             = 2;
+  optional int64        timestamp                = 3;
+  optional int64        serverReceivedTimestamp  = 5;
+  optional int64        serverDeliveredTimestamp = 6;
+  optional bool         needsReceipt             = 4;
+  optional string       serverGuid               = 7;
+  optional bytes        groupId                  = 8;
+  optional string       destinationUuid          = 9;
+}
+
+message AddressProto {
+  optional bytes  uuid  = 1;
+  optional string e164  = 2;
+}


### PR DESCRIPTION
This is a initial draft for message storage. The trait behind message storage is `MessageStore`, which is currently only has very basic functionality, e.g. storing and retrieving messages by sender and timestamp, listing all messages. This should definitely be expanded in the future with e.g. associating messages with channels/groups, listing messages from channels/groups. I don't think searching would be easily possible as sled (the main current implementation) is basically just a key-value store and not intended to be searchable (as far as I see).

The message serialization/deserialization is done using protobuf. I think the additional work done here (mainly the `InternalSerialization.proto` with function implementations) should be upstreamed to `libsignal-service-rs`

For receiving messages, there is a new function in the `Manager`, if the config store is also a messages store. This is only a thin wrapper around the normal receive function.
 
The example cli has also been updated to include use the new function for receiving and a argument for listing the current messages.

As already mentioned, this is still a early draft and only represents a idea on how this could be implemented. This idea should be discussed if this even is the right direction for this project.

This would close #44.

## Update

Associating messages with a contact/group is now implemented. I think the code is not as nice as it could be because `sled` does not seem to be made for such tasks, something like a real DB would be better suited. But it is working.