### PR TITLE
Update libsignal-service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Gabriel Féron <feron.gabriel@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "0f477049862da4d06dc27ca389c0edb3d38ce3c9" }
-libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs.git", rev = "0f477049862da4d06dc27ca389c0edb3d38ce3c9" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "f9b54478c5413252e810089fd9648b6351bcc3bf" }
+libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs.git", rev = "f9b54478c5413252e810089fd9648b6351bcc3bf" }
 
 async-trait = "0.1"
 base64 = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Gabriel Féron <feron.gabriel@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "1508fa8f3561e3807aa8d073ca05a61346ae5a82" }
-libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs.git", rev = "1508fa8f3561e3807aa8d073ca05a61346ae5a82" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "0f477049862da4d06dc27ca389c0edb3d38ce3c9" }
+libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs.git", rev = "0f477049862da4d06dc27ca389c0edb3d38ce3c9" }
 
 async-trait = "0.1"
 base64 = "0.12"

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -372,6 +372,7 @@ impl<C: ConfigStore> Manager<C, Confirmation> {
             .confirm_verification_code(
                 confirm_code,
                 AccountAttributes {
+                    name: "".to_string(),
                     signaling_key: Some(signaling_key.to_vec()),
                     registration_id,
                     voice: false,
@@ -383,10 +384,9 @@ impl<C: ConfigStore> Manager<C, Confirmation> {
                     unrestricted_unidentified_access: false, // TODO: make this configurable?
                     discoverable_by_phone_number: true,
                     capabilities: DeviceCapabilities {
-                        uuid: true,
                         gv2: true,
-                        storage: false,
                         gv1_migration: true,
+                        ..Default::default()
                     },
                 },
             )
@@ -466,6 +466,11 @@ impl<C: ConfigStore> Manager<C, Registered> {
             AccountManager::new(self.push_service()?, Some(*self.state.profile_key));
         account_manager
             .set_account_attributes(AccountAttributes {
+                name: self
+                    .state
+                    .device_name
+                    .clone()
+                    .expect("Device name to be set"),
                 registration_id: self.state.registration_id,
                 signaling_key: None,
                 voice: false,
@@ -477,10 +482,9 @@ impl<C: ConfigStore> Manager<C, Registered> {
                 unrestricted_unidentified_access: false,
                 discoverable_by_phone_number: true,
                 capabilities: DeviceCapabilities {
-                    uuid: true,
-                    storage: false,
                     gv2: true,
                     gv1_migration: true,
+                    ..Default::default()
                 },
             })
             .await?;


### PR DESCRIPTION
This enables the fix in <https://github.com/whisperfish/libsignal-service-rs/pull/119>. I am not completely sure what name to give the device when registering as primary device and I am also unsure what device-capabilities presage has, so I mostly left it at default in combination with the previous device capabilities.

No need to hurry merging.