### PR TITLE
Fix contacts syncing after linking

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -570,12 +570,12 @@ impl<C: Store> Manager<C, Registered> {
     }
 
     async fn sync_contacts(&mut self) -> Result<(), Error> {
+        let messages = self.receive_messages_stream(true).await?;
+        pin_mut!(messages);
+
         self.request_contacts_sync().await?;
 
         info!("waiting for contacts sync for up to 60 seconds");
-
-        let messages = self.receive_messages_stream(true).await?;
-        pin_mut!(messages);
 
         tokio::time::timeout(
             Duration::from_secs(60),


### PR DESCRIPTION
This previously returned `MessagePipeNotStarted` as the message pipe was not yet started when sending the request for contact syncing. This behavior was introduced in #106.