### PR TITLE
Clear messages

### DIFF
--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -154,6 +154,9 @@ impl TryFrom<&Content> for Thread {
 pub trait MessageStore {
     type MessagesIter: Iterator<Item = Result<Content, Error>>;
 
+    // Clear all stored messages.
+    fn clear_messages(&mut self) -> Result<(), Error>;
+
     /// Save a message in a [Thread] identified by a timestamp.
     /// TODO: deriving the thread happens from the content, so we can also ditch the first parameter
     fn save_message(&mut self, thread: &Thread, message: Content) -> Result<(), Error>;

--- a/src/store/secret_volatile.rs
+++ b/src/store/secret_volatile.rs
@@ -356,6 +356,10 @@ impl IdentityKeyStore for SecretVolatileStore {
 impl MessageStore for SecretVolatileStore {
     type MessagesIter = std::iter::Empty<Content>;
 
+    fn clear_messages(&mut self) -> Result<(), Error> {
+        todo!()
+    }
+
     fn save_message(&mut self, _thread: &Thread, _message: Content) -> Result<(), Error> {
         todo!()
     }

--- a/src/store/sled.rs
+++ b/src/store/sled.rs
@@ -733,6 +733,19 @@ impl SenderKeyStore for SledStore {
 impl MessageStore for SledStore {
     type MessagesIter = SledMessagesIter;
 
+    fn clear_messages(&mut self) -> Result<(), Error> {
+        for name in self.db.tree_names() {
+            if name
+                .as_ref()
+                .starts_with(SLED_TREE_THREAD_PREFIX.as_bytes())
+            {
+                self.db.drop_tree(&name)?;
+            }
+        }
+        self.db.flush()?;
+        Ok(())
+    }
+
     fn save_message(&mut self, thread: &Thread, message: Content) -> Result<(), Error> {
         log::trace!(
             "Storing a message with thread: {:?}, timestamp: {}",

--- a/src/store/volatile.rs
+++ b/src/store/volatile.rs
@@ -303,6 +303,10 @@ impl IdentityKeyStore for VolatileStore {
 impl MessageStore for VolatileStore {
     type MessagesIter = std::iter::Empty<Content>;
 
+    fn clear_messages(&mut self) -> Result<(), Error> {
+        todo!()
+    }
+
     fn save_message(&mut self, _thread: &Thread, _message: Content) -> Result<(), Error> {
         todo!()
     }


### PR DESCRIPTION
This (ab)uses the fact that all thread-trees start with `thread`. I don't know if that should be seen as an interpretation detail of `messages_thread_tree_name` and should therefore be clasified as a workaround. Another option may be to instead query possible `Thread` first and then calculate the thread name, but this would tightly couple the three Store-traits and one would be careful in which order to delete the data.