### PR TITLE
Fix retrieving message from a timestamp

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -133,6 +133,8 @@ enum Cmd {
             value_parser = parse_group_master_key,
         )]
         group_master_key: Option<GroupMasterKeyBytes>,
+        #[clap(long, help = "start from the following date (UNIX timestamp)")]
+        from: Option<u64>,
     },
     #[clap(about = "Get a single contact by UUID")]
     GetContact { uuid: Uuid },
@@ -587,13 +589,14 @@ async fn run<C: Store + MessageStore>(subcommand: Cmd, config_store: C) -> anyho
         Cmd::ListMessages {
             group_master_key,
             recipient_uuid,
+            from,
         } => {
             let thread = match (group_master_key, recipient_uuid) {
                 (Some(master_key), _) => Thread::Group(master_key),
                 (_, Some(uuid)) => Thread::Contact(uuid),
                 _ => unreachable!(),
             };
-            let iter = config_store.messages(&thread, None)?;
+            let iter = config_store.messages(&thread, from)?;
             for msg in iter.filter_map(Result::ok) {
                 println!("{:?}: {:?}", msg.metadata.sender, msg);
             }

--- a/src/store/sled.rs
+++ b/src/store/sled.rs
@@ -777,7 +777,7 @@ impl MessageStore for SledStore {
         let tree_thread = self.tree(self.messages_thread_tree_name(thread))?;
         debug!("{} messages in this tree", tree_thread.len());
         let iter = if let Some(from) = from {
-            tree_thread.range(..from.to_be_bytes())
+            tree_thread.range(from.to_be_bytes()..)
         } else {
             tree_thread.range::<&[u8], std::ops::RangeFull>(..)
         };


### PR DESCRIPTION
The range used for `sled` was inverted.

#116 