### PR TITLE
Attachment Store for caching attachments

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -219,7 +219,7 @@ async fn send<C: Store>(
 // Note to developers, this is a good example of a function you can use as a source of inspiration
 // to process incoming messages.
 async fn process_incoming_message<C: Store + MessageStore>(
-    manager: &Manager<C, Registered>,
+    manager: &mut Manager<C, Registered>,
     attachments_tmp_dir: &Path,
     notifications: bool,
     content: &Content,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -11,7 +11,7 @@ use libsignal_service::{
         },
         Content, Uuid,
     },
-    proto::{sync_message::Sent, DataMessage, GroupContextV2, SyncMessage},
+    proto::{sync_message::Sent, AttachmentPointer, DataMessage, GroupContextV2, SyncMessage},
 };
 use serde::{Deserialize, Serialize};
 
@@ -34,6 +34,7 @@ pub trait Store:
     + MessageStore
     + GroupsStore
     + SenderKeyStore
+    + AttachmentStore
     + Sync
     + Clone
 {
@@ -174,4 +175,20 @@ pub trait MessageStore {
         thread: &Thread,
         range: impl RangeBounds<u64>,
     ) -> Result<Self::MessagesIter, Error>;
+}
+
+/// Store for caching attachments.
+pub trait AttachmentStore {
+    /// Save an attachment to the store.
+    fn save_attachment(
+        &mut self,
+        attachment_pointer: &AttachmentPointer,
+        attachment: impl AsRef<[u8]>,
+    ) -> Result<(), Error>;
+
+    /// Retrieve a attachment from the store.
+    fn attachment(
+        &mut self,
+        attachment_pointer: &AttachmentPointer,
+    ) -> Result<Option<Vec<u8>>, Error>;
 }


### PR DESCRIPTION
This enables caching of attachments. Some notes:

- This assumes an `AttachmentIdentifier` of an `AttachmentPointer` uniquely references an attachment which may not change.
- We may also want to cache attachments when uploading.
- We may also want a method checking if there is a local version of the attachment.
- We probably want something to delete old attachments (similar to LRU-cache). Not yet sure how this can be implemented, but maybe one could add the timestamp of the save to the stored attachment and then iterate over all attachments (`O(n)`) and delete the old ones.