### PR TITLE
Cache for profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Gabriel Féron <g@leirbag.net>"]
 edition = "2021"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "964810f962c1b1c6530f749394f07aea731b6a74" }
-libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "964810f962c1b1c6530f749394f07aea731b6a74" }
+libsignal-service = { git = "https://github.com/Schmiddiii/libsignal-service-rs", rev = "40899c2" }
+libsignal-service-hyper = { git = "https://github.com/Schmiddiii/libsignal-service-rs", rev = "40899c2" }
 
 async-trait = "0.1"
 base64 = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Gabriel Féron <g@leirbag.net>"]
 edition = "2021"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/Schmiddiii/libsignal-service-rs", rev = "40899c2" }
-libsignal-service-hyper = { git = "https://github.com/Schmiddiii/libsignal-service-rs", rev = "40899c2" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "791c521" }
+libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "791c521" }
 
 async-trait = "0.1"
 base64 = "0.12"

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -219,7 +219,7 @@ async fn send<C: Store>(
 // Note to developers, this is a good example of a function you can use as a source of inspiration
 // to process incoming messages.
 async fn process_incoming_message<C: Store + MessageStore>(
-    manager: &Manager<C, Registered>,
+    manager: &mut Manager<C, Registered>,
     attachments_tmp_dir: &Path,
     notifications: bool,
     content: &Content,
@@ -497,7 +497,7 @@ async fn run<C: Store + MessageStore>(subcommand: Cmd, config_store: C) -> anyho
             uuid,
             mut profile_key,
         } => {
-            let manager = Manager::load_registered(config_store)?;
+            let mut manager = Manager::load_registered(config_store)?;
             if profile_key.is_none() {
                 for contact in manager
                     .contacts()?

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -630,19 +630,30 @@ impl<C: Store> Manager<C, Registered> {
     }
 
     /// Fetches the profile (name, about, status emoji) of the registered user.
-    pub async fn retrieve_profile(&self) -> Result<Profile, Error> {
+    pub async fn retrieve_profile(&mut self) -> Result<Profile, Error> {
         self.retrieve_profile_by_uuid(self.state.uuid, self.state.profile_key)
             .await
     }
 
     /// Fetches the profile of the provided user by UUID and profile key.
     pub async fn retrieve_profile_by_uuid(
-        &self,
+        &mut self,
         uuid: Uuid,
         profile_key: ProfileKey,
     ) -> Result<Profile, Error> {
+        // Check if profile is cached.
+        if let Some(profile) = self.config_store.profile(uuid, profile_key).ok().flatten() {
+            return Ok(profile);
+        }
+
         let mut account_manager = AccountManager::new(self.push_service()?, Some(profile_key));
-        Ok(account_manager.retrieve_profile(uuid.into()).await?)
+
+        let profile = account_manager.retrieve_profile(uuid.into()).await?;
+
+        let _ = self
+            .config_store
+            .save_profile(uuid, profile_key, profile.clone());
+        Ok(profile)
     }
 
     /// Get a single contact by its UUID

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -9,9 +9,10 @@ use libsignal_service::{
         protocol::{
             IdentityKeyStore, PreKeyStore, SenderKeyStore, SessionStoreExt, SignedPreKeyStore,
         },
-        Content, Uuid,
+        Content, ProfileKey, Uuid,
     },
     proto::{sync_message::Sent, DataMessage, GroupContextV2, SyncMessage},
+    Profile,
 };
 use serde::{Deserialize, Serialize};
 
@@ -33,6 +34,7 @@ pub trait Store:
     + ContactsStore
     + MessageStore
     + GroupsStore
+    + ProfilesStore
     + SenderKeyStore
     + Sync
     + Clone
@@ -174,4 +176,13 @@ pub trait MessageStore {
         thread: &Thread,
         range: impl RangeBounds<u64>,
     ) -> Result<Self::MessagesIter, Error>;
+}
+
+/// Cache profiles locally.
+pub trait ProfilesStore {
+    /// Save a profile by [Uuid] and [ProfileKey].
+    fn save_profile(&mut self, uuid: Uuid, key: ProfileKey, profile: Profile) -> Result<(), Error>;
+
+    /// Retrieve a profile by [Uuid] and [ProfileKey].
+    fn profile(&self, uuid: Uuid, key: ProfileKey) -> Result<Option<Profile>, Error>;
 }


### PR DESCRIPTION
~~Dependent on upstream PR <https://github.com/whisperfish/libsignal-service-rs/pull/207>. Therefore, my fork is currently uses but should be changed to upstream as soon as merged there.~~

This is very similar to <https://github.com/whisperfish/presage/pull/130> and provides pretty much the same functionality for profiles.

Maybe after both are merged, a function `clear_cache` would be useful for the stores.