### PR TITLE
Fix duplicate message to group

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -893,7 +893,12 @@ impl<C: Store> Manager<C, Registered> {
             return Err(Error::UnknownGroup);
         };
 
-        let recipients: Vec<_> = group.members.into_iter().map(|m| m.uuid.into()).collect();
+        let recipients: Vec<_> = group
+            .members
+            .into_iter()
+            .filter(|m| m.uuid != self.state.uuid)
+            .map(|m| m.uuid.into())
+            .collect();
 
         let online_only = false;
         let results = sender


### PR DESCRIPTION
Currently, when sendinging a message to a group, this message will be sent both as a data message to linked devices and as a sync message. As discussed in the whisperfish-chat, the recipients-list should not contain the own UUID. As also discussed, this breaks sending to groups with only the sender and no other persons, this has to be fixed upstream.