### PR TITLE
Store decrypted groups

### DIFF
--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Gabriel Féron <g@leirbag.net>"]
 edition = "2021"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "c2f70ef" }
-libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "c2f70ef" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "a2e871a" }
+libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "a2e871a" }
 
 base64 = "0.12"
 futures = "0.3"

--- a/presage/src/lib.rs
+++ b/presage/src/lib.rs
@@ -18,6 +18,7 @@ pub mod prelude {
             self, Content, ContentBody, DataMessage, GroupContext, GroupContextV2, GroupType,
             Metadata, SyncMessage,
         },
+        groups_v2::{AccessControl, Group, GroupChange, PendingMember, RequestingMember, Timer},
         models::Contact,
         prelude::{
             phonenumber::{self, PhoneNumber},

--- a/presage/src/store.rs
+++ b/presage/src/store.rs
@@ -103,11 +103,8 @@ pub trait Store: ProtocolStore + SenderKeyStore + SessionStoreExt + Sync + Clone
     fn clear_groups(&mut self) -> Result<(), Self::Error>;
 
     /// Save a group in the cache
-    fn save_group(
-        &self,
-        master_key: GroupMasterKeyBytes,
-        group: crate::prelude::proto::Group,
-    ) -> Result<(), Self::Error>;
+    fn save_group(&self, master_key: GroupMasterKeyBytes, group: &Group)
+        -> Result<(), Self::Error>;
 
     /// Get an iterator on all cached groups
     fn groups(&self) -> Result<Self::GroupsIter, Self::Error>;

--- a/presage/src/store.rs
+++ b/presage/src/store.rs
@@ -72,6 +72,18 @@ pub trait Store: ProtocolStore + SenderKeyStore + SessionStoreExt + Sync + Clone
         range: impl RangeBounds<u64>,
     ) -> Result<Self::MessagesIter, Self::Error>;
 
+    /// Get the expire timer from a [Thread], which corresponds to either [Contact::expire_timer]
+    /// or [Group::disappearing_messages_timer].
+    fn expire_timer(&self, thread: &Thread) -> Result<Option<u32>, Self::Error> {
+        match thread {
+            Thread::Contact(uuid) => Ok(self.contact_by_id(*uuid)?.map(|c| c.expire_timer)),
+            Thread::Group(key) => Ok(self
+                .group(*key)?
+                .and_then(|g| g.disappearing_messages_timer)
+                .map(|t| t.duration)),
+        }
+    }
+
     /// Contacts
 
     /// Clear all saved synchronized contact data


### PR DESCRIPTION
* This meant a much higher CPU usage than expected when loading groups often as we would decrypt groups whenever they're accessed.
* Since the store can be optionally encrypted with a passphrase, this would also means the data was encrypted twice.

cc: @nanu-c 

Closes #122 