### PR TITLE
Re-introduce RwLock around sled::Db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix synchronization issue in the `sled` store implementation which could lead to corrupted sessions. (#162)
+
 ### Changed
 
 ## [0.5.1]


### PR DESCRIPTION
Since we receive events asynchronously in the websocket, and spawn decryption, it is very important that we guard concurrent decryption as it can perform write operations on the store.

This is probably the reason of session storage corruption like reported in #158.