### PR TITLE
manager: continue when skipping internal msgs

### DIFF
--- a/presage/src/manager.rs
+++ b/presage/src/manager.rs
@@ -869,7 +869,7 @@ impl<C: Store> Manager<C, Registered> {
                                     if state.include_internal_events {
                                         return Some((content, state));
                                     } else {
-                                        return None;
+                                        continue;
                                     }
                                 }
 


### PR DESCRIPTION
I noticed that sometimes `receive_messages()` will terminate instead of blocking for new messages. When internal messages aren't desired, the closure returns `None`. I believe this causes `futures::stream::unfold()` to return `Poll::Ready(None)` which will close the stream. I don't think that's what we want.

I suggest we just continue looping when skipping internal messages instead of returning None.