### PR TITLE
Set the expire timer

### DIFF
--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Gabriel Féron <g@leirbag.net>"]
 edition = "2021"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "c2f70ef" }
-libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "c2f70ef" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "a2e871a" }
+libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "a2e871a" }
 
 base64 = "0.12"
 futures = "0.3"

--- a/presage/src/store.rs
+++ b/presage/src/store.rs
@@ -72,6 +72,18 @@ pub trait Store: ProtocolStore + SenderKeyStore + SessionStoreExt + Sync + Clone
         range: impl RangeBounds<u64>,
     ) -> Result<Self::MessagesIter, Self::Error>;
 
+    /// Get the expire timer from a [Thread], which corresponds to either [Contact::expire_timer]
+    /// or [Group::disappearing_messages_timer].
+    fn expire_timer(&self, thread: &Thread) -> Result<Option<u32>, Self::Error> {
+        match thread {
+            Thread::Contact(uuid) => Ok(self.contact_by_id(*uuid)?.map(|c| c.expire_timer)),
+            Thread::Group(key) => Ok(self
+                .group(*key)?
+                .and_then(|g| g.disappearing_messages_timer)
+                .map(|t| t.duration)),
+        }
+    }
+
     /// Contacts
 
     /// Clear all saved synchronized contact data


### PR DESCRIPTION
This sets the expire timer of a message such that the current expiration timer of a conversation stays the same (except in cases where it was explicitly set to another value).

It may be a little counterproductive when sending a message to (e.g.) a contact to query the timer for the thread which unwraps it back to querying the contact, but this method may potentially also be used to display the expiration timer.

Note that due to #171, I would guess that the expiration timer always stays the same for contacts directly after linking, e.g. changing it on an official client and then sending a message from presage, presage will set the expiration timer back to before the change.

This fixes #93.

P.S.: The panic when the group bytes are not 32 bytes in length is maybe not that good. Is there a reason for the parameter not being `[u8; 32]`?