### PR TITLE
Introduce capability to import an existing registration

### DIFF
--- a/presage/src/lib.rs
+++ b/presage/src/lib.rs
@@ -5,7 +5,7 @@ mod serde;
 mod store;
 
 pub use errors::Error;
-pub use manager::{Confirmation, Linking, Manager, Registered, Registration, RegistrationOptions};
+pub use manager::{Confirmation, Linking, Manager, Registered, Registration, RegistrationOptions, RegistrationInfo};
 pub use store::{Store, StoreError, Thread};
 
 #[deprecated(note = "Please help use improve the prelude module instead")]


### PR DESCRIPTION
This should add the capability to import an existing registration.

I don't have deeper understanding of presage and only build what looked right.

Please comment if this is in the right direction and point out issues.

The examples do not compile, because SledStore is no module of the crate `presage` (anymore?).