### PR TITLE
Fix arg group syntax

### DIFF
--- a/presage-cli/src/main.rs
+++ b/presage-cli/src/main.rs
@@ -126,7 +126,7 @@ enum Cmd {
         group(
             ArgGroup::new("list-messages")
                 .required(true)
-                .args(&["recipient-uuid", "group-master-key"])
+                .args(&["recipient_uuid", "group_master_key"])
         )
     )]
     ListMessages {


### PR DESCRIPTION
The clap arg-group needs the field name of the struct

Otherwise you get this:
```bash
thread 'main' panicked at 'Command list-messages: Argument group 'list-messages' contains non-existent argument 'recipient-uuid'', /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.3.19/src/builder/debug_asserts.rs:292:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
After:
```bash
error: the following required arguments were not provided:
  <--recipient-uuid <RECIPIENT_UUID>|--group-master-key <GROUP_MASTER_KEY>>

Usage: presage-cli list-messages <--recipient-uuid <RECIPIENT_UUID>|--group-master-key <GROUP_MASTER_KEY>>

For more information, try '--help'.
```
Which is expected