### PR TITLE
Fix registration without force

### DIFF
--- a/presage/src/manager.rs
+++ b/presage/src/manager.rs
@@ -188,7 +188,7 @@ impl<C: Store> Manager<C, Registration> {
         } = registration_options;
 
         // check if we are already registered
-        if !force && config_store.load_state().is_ok() {
+        if !force && config_store.is_registered() {
             return Err(Error::AlreadyRegisteredError);
         }
 


### PR DESCRIPTION
In the presage-store-sled implementation, `load_state` always returns `Ok(_)` (except for errors). Therefore, the registration condition that determines if the store was already registered, `!force && config_store.load_state.is_ok()` is always `true` when `force == false`. Instead, one should use `config_store.is_registered()` to figure out if the store is already registered.