### PR TITLE
feat: Add receiving mode to the message stream

### DIFF
--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Gabriel Féron <g@leirbag.net>"]
 edition = "2021"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "454d234" }
-libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "454d234" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "a36d43d62" }
+libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "a36d43d62" }
 
 base64 = "0.21"
 futures = "0.3"

--- a/presage/src/lib.rs
+++ b/presage/src/lib.rs
@@ -5,7 +5,9 @@ mod serde;
 mod store;
 
 pub use errors::Error;
-pub use manager::{Confirmation, Linking, Manager, Registered, Registration, RegistrationOptions};
+pub use manager::{
+    Confirmation, Linking, Manager, ReceivingMode, Registered, Registration, RegistrationOptions,
+};
 pub use store::{ContentTimestamp, Store, StoreError, Thread};
 
 #[deprecated(note = "Please help use improve the prelude module instead")]


### PR DESCRIPTION
Add a new method `Manager::receive_messages_with_mode` allowing to
configure how to handle specific sentinel messages. It is supported to
stop the stream after the initial sync (empty Signal message queue) or
after contact sync.