### PR TITLE
Split into multiple module, document all structs and general cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,13 +41,13 @@ jobs:
           command: build
           args: --all-targets ${{ matrix.cargo_flags }}
 
-      - name: Run tests
+      - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-targets ${{ matrix.cargo_flags }}
 
-      - name: Run doc tests
+      - name: Test docs
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/presage-cli/src/main.rs
+++ b/presage-cli/src/main.rs
@@ -14,20 +14,23 @@ use futures::StreamExt;
 use futures::{channel::oneshot, future, pin_mut};
 use log::{debug, error, info};
 use notify_rust::Notification;
+use presage::libsignal_service::configuration::SignalServers;
 use presage::libsignal_service::content::Reaction;
+use presage::libsignal_service::models::Contact;
+use presage::libsignal_service::prelude::phonenumber::PhoneNumber;
+use presage::libsignal_service::prelude::Uuid;
 use presage::libsignal_service::proto::data_message::Quote;
 use presage::libsignal_service::proto::sync_message::Sent;
+use presage::libsignal_service::zkgroup::GroupMasterKeyBytes;
 use presage::libsignal_service::{groups_v2::Group, prelude::ProfileKey};
-use presage::prelude::proto::EditMessage;
-use presage::prelude::SyncMessage;
-use presage::ContentTimestamp;
+use presage::proto::EditMessage;
+use presage::proto::SyncMessage;
+use presage::store::ContentExt;
 use presage::{
-    prelude::{
-        content::{Content, ContentBody, DataMessage, GroupContextV2},
-        Contact, SignalServers,
-    },
-    prelude::{phonenumber::PhoneNumber, Uuid},
-    GroupMasterKeyBytes, Manager, Registered, RegistrationOptions, Store, Thread,
+    libsignal_service::content::{Content, ContentBody, DataMessage, GroupContextV2},
+    manager::{Registered, RegistrationOptions},
+    store::{Store, Thread},
+    Manager,
 };
 use presage_store_sled::MigrationConflictStrategy;
 use presage_store_sled::SledStore;

--- a/presage-cli/src/main.rs
+++ b/presage-cli/src/main.rs
@@ -207,10 +207,10 @@ async fn main() -> anyhow::Result<()> {
     run(args.subcommand, config_store).await
 }
 
-async fn send<C: Store + 'static>(
+async fn send<S: Store + 'static>(
     msg: &str,
     uuid: &Uuid,
-    manager: &mut Manager<C, Registered>,
+    manager: &mut Manager<S, Registered>,
 ) -> anyhow::Result<()> {
     let timestamp = std::time::SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -250,8 +250,8 @@ async fn send<C: Store + 'static>(
 
 // Note to developers, this is a good example of a function you can use as a source of inspiration
 // to process incoming messages.
-async fn process_incoming_message<C: Store>(
-    manager: &mut Manager<C, Registered>,
+async fn process_incoming_message<S: Store>(
+    manager: &mut Manager<S, Registered>,
     attachments_tmp_dir: &Path,
     notifications: bool,
     content: &Content,
@@ -289,8 +289,8 @@ async fn process_incoming_message<C: Store>(
     }
 }
 
-fn print_message<C: Store>(
-    manager: &Manager<C, Registered>,
+fn print_message<S: Store>(
+    manager: &Manager<S, Registered>,
     notifications: bool,
     content: &Content,
 ) {
@@ -438,8 +438,8 @@ fn print_message<C: Store>(
     }
 }
 
-async fn receive<C: Store>(
-    manager: &mut Manager<C, Registered>,
+async fn receive<S: Store>(
+    manager: &mut Manager<S, Registered>,
     notifications: bool,
 ) -> anyhow::Result<()> {
     let attachments_tmp_dir = Builder::new().prefix("presage-attachments").tempdir()?;
@@ -462,7 +462,7 @@ async fn receive<C: Store>(
     Ok(())
 }
 
-async fn run<C: Store + 'static>(subcommand: Cmd, config_store: C) -> anyhow::Result<()> {
+async fn run<S: Store + 'static>(subcommand: Cmd, config_store: S) -> anyhow::Result<()> {
     match subcommand {
         Cmd::Register {
             servers,

--- a/presage-store-sled/src/error.rs
+++ b/presage-store-sled/src/error.rs
@@ -1,4 +1,4 @@
-use presage::{libsignal_service::protocol::SignalProtocolError, StoreError};
+use presage::{libsignal_service::protocol::SignalProtocolError, store::StoreError};
 
 #[derive(Debug, thiserror::Error)]
 pub enum SledStoreError {

--- a/presage-store-sled/src/lib.rs
+++ b/presage-store-sled/src/lib.rs
@@ -7,32 +7,31 @@ use std::{
 
 use async_trait::async_trait;
 use log::{debug, error, trace, warn};
-use presage::{
-    libsignal_service::{
-        self,
-        groups_v2::Group,
-        models::Contact,
-        prelude::{Content, ProfileKey, Uuid},
-        protocol::{
-            Direction, GenericSignedPreKey, IdentityKey, IdentityKeyPair, IdentityKeyStore,
-            KyberPreKeyId, KyberPreKeyRecord, KyberPreKeyStore, PreKeyId, PreKeyRecord,
-            PreKeyStore, ProtocolAddress, ProtocolStore, SenderKeyRecord, SenderKeyStore,
-            SessionRecord, SessionStore, SignalProtocolError, SignedPreKeyId, SignedPreKeyRecord,
-            SignedPreKeyStore,
-        },
-        push_service::DEFAULT_DEVICE_ID,
-        session_store::SessionStoreExt,
-        Profile, ServiceAddress,
+use presage::libsignal_service::zkgroup::GroupMasterKeyBytes;
+use presage::libsignal_service::{
+    self,
+    content::Content,
+    groups_v2::Group,
+    models::Contact,
+    prelude::{ProfileKey, Uuid},
+    protocol::{
+        Direction, GenericSignedPreKey, IdentityKey, IdentityKeyPair, IdentityKeyStore,
+        KyberPreKeyId, KyberPreKeyRecord, KyberPreKeyStore, PreKeyId, PreKeyRecord, PreKeyStore,
+        ProtocolAddress, ProtocolStore, SenderKeyRecord, SenderKeyStore, SessionRecord,
+        SessionStore, SignalProtocolError, SignedPreKeyId, SignedPreKeyRecord, SignedPreKeyStore,
     },
-    ContentTimestamp,
+    push_service::DEFAULT_DEVICE_ID,
+    session_store::SessionStoreExt,
+    Profile, ServiceAddress,
 };
+use presage::manager::Registered;
+use presage::store::{ContentExt, ContentsStore, PrekeysStore, StateStore, Store, Thread};
 use prost::Message;
-use protobuf::ContentProto;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sled::{Batch, IVec};
 
-use presage::{GroupMasterKeyBytes, Registered, Store, Thread};
+use crate::protobuf::ContentProto;
 
 mod error;
 mod protobuf;
@@ -364,14 +363,8 @@ fn migrate(
 
 impl ProtocolStore for SledStore {}
 
-impl Store for SledStore {
-    type Error = SledStoreError;
-
-    type ContactsIter = SledContactsIter;
-    type GroupsIter = SledGroupsIter;
-    type MessagesIter = SledMessagesIter;
-
-    /// State
+impl StateStore for SledStore {
+    type StateStoreError = SledStoreError;
 
     fn load_state(&self) -> Result<Option<Registered>, SledStoreError> {
         self.get(SLED_TREE_STATE, SLED_KEY_REGISTRATION)
@@ -403,63 +396,14 @@ impl Store for SledStore {
 
         Ok(())
     }
+}
 
-    fn clear(&mut self) -> Result<(), SledStoreError> {
-        self.clear_registration()?;
+impl ContentsStore for SledStore {
+    type ContentsStoreError = SledStoreError;
 
-        let db = self.write();
-        db.drop_tree(SLED_TREE_CONTACTS)?;
-        db.drop_tree(SLED_TREE_GROUPS)?;
-
-        for tree in db
-            .tree_names()
-            .into_iter()
-            .filter(|n| n.starts_with(SLED_TREE_THREADS_PREFIX.as_bytes()))
-        {
-            db.drop_tree(tree)?;
-        }
-
-        db.flush()?;
-
-        Ok(())
-    }
-
-    /// Pre-keys
-
-    fn pre_keys_offset_id(&self) -> Result<u32, SledStoreError> {
-        Ok(self
-            .get(SLED_TREE_STATE, SLED_KEY_PRE_KEYS_OFFSET_ID)?
-            .unwrap_or(0))
-    }
-
-    fn set_pre_keys_offset_id(&mut self, id: u32) -> Result<(), SledStoreError> {
-        self.insert(SLED_TREE_STATE, SLED_KEY_PRE_KEYS_OFFSET_ID, id)?;
-        Ok(())
-    }
-
-    fn next_signed_pre_key_id(&self) -> Result<u32, SledStoreError> {
-        Ok(self
-            .get(SLED_TREE_STATE, SLED_KEY_NEXT_SIGNED_PRE_KEY_ID)?
-            .unwrap_or(0))
-    }
-
-    fn set_next_signed_pre_key_id(&mut self, id: u32) -> Result<(), SledStoreError> {
-        self.insert(SLED_TREE_STATE, SLED_KEY_NEXT_SIGNED_PRE_KEY_ID, id)?;
-        Ok(())
-    }
-
-    fn next_pq_pre_key_id(&self) -> Result<u32, SledStoreError> {
-        Ok(self
-            .get(SLED_TREE_STATE, SLED_KEY_NEXT_PQ_PRE_KEY_ID)?
-            .unwrap_or(0))
-    }
-
-    fn set_next_pq_pre_key_id(&mut self, id: u32) -> Result<(), SledStoreError> {
-        self.insert(SLED_TREE_STATE, SLED_KEY_NEXT_PQ_PRE_KEY_ID, id)?;
-        Ok(())
-    }
-
-    /// Contacts
+    type ContactsIter = SledContactsIter;
+    type GroupsIter = SledGroupsIter;
+    type MessagesIter = SledMessagesIter;
 
     fn clear_contacts(&mut self) -> Result<(), SledStoreError> {
         self.write().drop_tree(SLED_TREE_CONTACTS)?;
@@ -643,6 +587,67 @@ impl Store for SledStore {
     fn profile(&self, uuid: Uuid, key: ProfileKey) -> Result<Option<Profile>, SledStoreError> {
         let key = self.profile_key_for_uuid(uuid, key);
         self.get(SLED_TREE_PROFILES, key)
+    }
+}
+
+impl PrekeysStore for SledStore {
+    type PrekeysStoreError = SledStoreError;
+
+    fn pre_keys_offset_id(&self) -> Result<u32, SledStoreError> {
+        Ok(self
+            .get(SLED_TREE_STATE, SLED_KEY_PRE_KEYS_OFFSET_ID)?
+            .unwrap_or(0))
+    }
+
+    fn set_pre_keys_offset_id(&mut self, id: u32) -> Result<(), SledStoreError> {
+        self.insert(SLED_TREE_STATE, SLED_KEY_PRE_KEYS_OFFSET_ID, id)?;
+        Ok(())
+    }
+
+    fn next_signed_pre_key_id(&self) -> Result<u32, SledStoreError> {
+        Ok(self
+            .get(SLED_TREE_STATE, SLED_KEY_NEXT_SIGNED_PRE_KEY_ID)?
+            .unwrap_or(0))
+    }
+
+    fn set_next_signed_pre_key_id(&mut self, id: u32) -> Result<(), SledStoreError> {
+        self.insert(SLED_TREE_STATE, SLED_KEY_NEXT_SIGNED_PRE_KEY_ID, id)?;
+        Ok(())
+    }
+
+    fn next_pq_pre_key_id(&self) -> Result<u32, SledStoreError> {
+        Ok(self
+            .get(SLED_TREE_STATE, SLED_KEY_NEXT_PQ_PRE_KEY_ID)?
+            .unwrap_or(0))
+    }
+
+    fn set_next_pq_pre_key_id(&mut self, id: u32) -> Result<(), SledStoreError> {
+        self.insert(SLED_TREE_STATE, SLED_KEY_NEXT_PQ_PRE_KEY_ID, id)?;
+        Ok(())
+    }
+}
+
+impl Store for SledStore {
+    type Error = SledStoreError;
+
+    fn clear(&mut self) -> Result<(), SledStoreError> {
+        self.clear_registration()?;
+
+        let db = self.write();
+        db.drop_tree(SLED_TREE_CONTACTS)?;
+        db.drop_tree(SLED_TREE_GROUPS)?;
+
+        for tree in db
+            .tree_names()
+            .into_iter()
+            .filter(|n| n.starts_with(SLED_TREE_THREADS_PREFIX.as_bytes()))
+        {
+            db.drop_tree(tree)?;
+        }
+
+        db.flush()?;
+
+        Ok(())
     }
 }
 
@@ -1098,19 +1103,17 @@ impl DoubleEndedIterator for SledMessagesIter {
 mod tests {
     use core::fmt;
 
-    use presage::{
-        libsignal_service::{
-            content::{ContentBody, Metadata},
-            prelude::Uuid,
-            proto::DataMessage,
-            protocol::{
-                self, Direction, GenericSignedPreKey, IdentityKeyStore, PreKeyRecord, PreKeyStore,
-                SessionRecord, SessionStore, SignedPreKeyRecord, SignedPreKeyStore,
-            },
-            ServiceAddress,
+    use presage::libsignal_service::{
+        content::{ContentBody, Metadata},
+        prelude::Uuid,
+        proto::DataMessage,
+        protocol::{
+            self, Direction, GenericSignedPreKey, IdentityKeyStore, PreKeyRecord, PreKeyStore,
+            SessionRecord, SessionStore, SignedPreKeyRecord, SignedPreKeyStore,
         },
-        Store,
+        ServiceAddress,
     };
+    use presage::store::ContentsStore;
     use quickcheck::{Arbitrary, Gen};
 
     use super::SledStore;
@@ -1122,10 +1125,10 @@ mod tests {
     struct KeyPair(protocol::KeyPair);
 
     #[derive(Debug, Clone)]
-    struct Thread(presage::Thread);
+    struct Thread(presage::store::Thread);
 
     #[derive(Debug, Clone)]
-    struct Content(presage::prelude::Content);
+    struct Content(presage::libsignal_service::content::Content);
 
     impl fmt::Debug for KeyPair {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1170,13 +1173,16 @@ mod tests {
                 timestamp: Some(timestamp),
                 ..Default::default()
             });
-            Self(presage::prelude::Content::from_body(content_body, metadata))
+            Self(presage::libsignal_service::content::Content::from_body(
+                content_body,
+                metadata,
+            ))
         }
     }
 
     impl Arbitrary for Thread {
         fn arbitrary(g: &mut Gen) -> Self {
-            Self(presage::Thread::Contact(Uuid::from_u128(
+            Self(presage::store::Thread::Contact(Uuid::from_u128(
                 Arbitrary::arbitrary(g),
             )))
         }
@@ -1247,8 +1253,11 @@ mod tests {
             == signed_pre_key_record.serialize().unwrap()
     }
 
-    fn content_with_timestamp(content: &Content, ts: u64) -> presage::prelude::Content {
-        presage::prelude::Content {
+    fn content_with_timestamp(
+        content: &Content,
+        ts: u64,
+    ) -> presage::libsignal_service::content::Content {
+        presage::libsignal_service::content::Content {
             metadata: Metadata {
                 timestamp: ts,
                 ..content.0.metadata.clone()

--- a/presage-store-sled/src/lib.rs
+++ b/presage-store-sled/src/lib.rs
@@ -25,7 +25,7 @@ use presage::libsignal_service::{
     Profile, ServiceAddress,
 };
 use presage::manager::Registered;
-use presage::store::{ContentExt, ContentsStore, PrekeysStore, StateStore, Store, Thread};
+use presage::store::{ContentExt, ContentsStore, PreKeyStoreExt, StateStore, Store, Thread};
 use prost::Message;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -590,8 +590,8 @@ impl ContentsStore for SledStore {
     }
 }
 
-impl PrekeysStore for SledStore {
-    type PrekeysStoreError = SledStoreError;
+impl PreKeyStoreExt for SledStore {
+    type PreKeyStoreExtError = SledStoreError;
 
     fn pre_keys_offset_id(&self) -> Result<u32, SledStoreError> {
         Ok(self

--- a/presage-store-sled/src/protobuf.rs
+++ b/presage-store-sled/src/protobuf.rs
@@ -4,15 +4,16 @@ mod textsecure {
     include!(concat!(env!("OUT_DIR"), "/textsecure.rs"));
 }
 
+use presage::libsignal_service::content::Content;
+use presage::libsignal_service::content::ContentBody;
+use presage::libsignal_service::content::Metadata;
+use presage::libsignal_service::proto;
+use presage::libsignal_service::ServiceAddress;
+
 use crate::SledStoreError;
 
 use self::textsecure::AddressProto;
 use self::textsecure::MetadataProto;
-use presage::prelude::content::ContentBody;
-use presage::prelude::content::Metadata;
-use presage::prelude::proto;
-use presage::prelude::Content;
-use presage::prelude::ServiceAddress;
 
 impl From<ServiceAddress> for AddressProto {
     fn from(s: ServiceAddress) -> Self {

--- a/presage/src/errors.rs
+++ b/presage/src/errors.rs
@@ -6,6 +6,7 @@ use libsignal_service::{
 
 use crate::store::StoreError;
 
+/// The error type of Signal manager
 #[derive(thiserror::Error, Debug)]
 pub enum Error<S: std::error::Error> {
     #[error("captcha from https://signalcaptchas.org/registration/generate.html required")]

--- a/presage/src/lib.rs
+++ b/presage/src/lib.rs
@@ -1,38 +1,14 @@
 mod cache;
 mod errors;
-mod manager;
+pub mod manager;
 mod serde;
-mod store;
+pub mod store;
+
+pub use libsignal_service;
+/// Protobufs used in Signal protocol and service communication
+pub use libsignal_service::proto;
 
 pub use errors::Error;
-pub use manager::{
-    Confirmation, Linking, Manager, ReceivingMode, Registered, Registration, RegistrationOptions,
-};
-pub use store::{ContentTimestamp, Store, StoreError, Thread};
-
-#[deprecated(note = "Please help use improve the prelude module instead")]
-pub use libsignal_service;
-
-pub mod prelude {
-    pub use libsignal_service::{
-        configuration::SignalServers,
-        content::{
-            self, Content, ContentBody, DataMessage, GroupContext, GroupContextV2, GroupType,
-            Metadata, SyncMessage,
-        },
-        groups_v2::{AccessControl, Group, GroupChange, PendingMember, RequestingMember, Timer},
-        models::Contact,
-        prelude::{
-            phonenumber::{self, PhoneNumber},
-            GroupMasterKey, GroupSecretParams, Uuid,
-        },
-        proto,
-        sender::AttachmentSpec,
-        ParseServiceAddressError, ServiceAddress,
-    };
-}
+pub use manager::Manager;
 
 const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "-rs-", env!("CARGO_PKG_VERSION"));
-
-// TODO: open a PR in libsignal and make sure the bytes can be read from `GroupMasterKey` instead of using this type
-pub type GroupMasterKeyBytes = [u8; 32];

--- a/presage/src/manager/confirmation.rs
+++ b/presage/src/manager/confirmation.rs
@@ -1,0 +1,159 @@
+use libsignal_service::configuration::{ServiceConfiguration, SignalServers};
+use libsignal_service::messagepipe::ServiceCredentials;
+use libsignal_service::prelude::phonenumber::PhoneNumber;
+use libsignal_service::protocol::KeyPair;
+use libsignal_service::provisioning::generate_registration_id;
+use libsignal_service::push_service::{
+    AccountAttributes, DeviceCapabilities, PushService, RegistrationMethod, ServiceIds,
+};
+use libsignal_service::zkgroup::profiles::ProfileKey;
+use libsignal_service_hyper::push_service::HyperPushService;
+use log::trace;
+use rand::rngs::StdRng;
+use rand::{RngCore, SeedableRng};
+
+use crate::cache::CacheCell;
+use crate::store::Store;
+use crate::{Error, Manager};
+
+use super::Registered;
+
+/// Manager state after a successful registration of new main device
+///
+/// In this state, the user has to confirm the new registration via a validation code.
+pub struct Confirmation {
+    pub(crate) signal_servers: SignalServers,
+    pub(crate) phone_number: PhoneNumber,
+    pub(crate) password: String,
+    pub(crate) session_id: String,
+}
+
+impl<C: Store> Manager<C, Confirmation> {
+    /// Confirm a newly registered account using the code you
+    /// received by SMS or phone call.
+    ///
+    /// Returns a [registered manager](Manager::load_registered) that you can use
+    /// to send and receive messages.
+    pub async fn confirm_verification_code(
+        self,
+        confirmation_code: impl AsRef<str>,
+    ) -> Result<Manager<C, Registered>, Error<C::Error>> {
+        trace!("confirming verification code");
+
+        let registration_id = generate_registration_id(&mut StdRng::from_entropy());
+        let pni_registration_id = generate_registration_id(&mut StdRng::from_entropy());
+
+        let Confirmation {
+            signal_servers,
+            phone_number,
+            password,
+            session_id,
+        } = self.state;
+
+        let credentials = ServiceCredentials {
+            uuid: None,
+            phonenumber: phone_number.clone(),
+            password: Some(password.clone()),
+            signaling_key: None,
+            device_id: None,
+        };
+
+        let service_configuration: ServiceConfiguration = signal_servers.into();
+        let mut push_service = HyperPushService::new(
+            service_configuration,
+            Some(credentials),
+            crate::USER_AGENT.to_string(),
+        );
+
+        let session = push_service
+            .submit_verification_code(&session_id, confirmation_code.as_ref())
+            .await?;
+
+        trace!("verification code submitted");
+
+        if !session.verified {
+            return Err(Error::UnverifiedRegistrationSession);
+        }
+
+        let mut rng = StdRng::from_entropy();
+
+        // generate a 52 bytes signaling key
+        let mut signaling_key = [0u8; 52];
+        rng.fill_bytes(&mut signaling_key);
+
+        let mut profile_key = [0u8; 32];
+        rng.fill_bytes(&mut profile_key);
+
+        let profile_key = ProfileKey::generate(profile_key);
+
+        let skip_device_transfer = false;
+        let registered = push_service
+            .submit_registration_request(
+                RegistrationMethod::SessionId(&session_id),
+                AccountAttributes {
+                    name: None,
+                    signaling_key: Some(signaling_key.to_vec()),
+                    registration_id,
+                    pni_registration_id,
+                    voice: false,
+                    video: false,
+                    fetches_messages: true,
+                    pin: None,
+                    registration_lock: None,
+                    unidentified_access_key: Some(profile_key.derive_access_key().to_vec()),
+                    unrestricted_unidentified_access: false, // TODO: make this configurable?
+                    discoverable_by_phone_number: true,
+                    capabilities: DeviceCapabilities {
+                        gv2: true,
+                        gv1_migration: true,
+                        ..Default::default()
+                    },
+                },
+                skip_device_transfer,
+            )
+            .await?;
+
+        let aci_identity_key_pair = KeyPair::generate(&mut rng);
+        let pni_identity_key_pair = KeyPair::generate(&mut rng);
+
+        trace!("confirmed! (and registered)");
+
+        let mut manager = Manager {
+            rng,
+            config_store: self.config_store,
+            state: Registered {
+                push_service_cache: CacheCell::default(),
+                identified_websocket: Default::default(),
+                unidentified_websocket: Default::default(),
+                unidentified_sender_certificate: Default::default(),
+                signal_servers: self.state.signal_servers,
+                device_name: None,
+                phone_number,
+                service_ids: ServiceIds {
+                    aci: registered.uuid,
+                    pni: registered.pni,
+                },
+                password,
+                signaling_key,
+                device_id: None,
+                registration_id,
+                pni_registration_id: Some(pni_registration_id),
+                aci_private_key: aci_identity_key_pair.private_key,
+                aci_public_key: aci_identity_key_pair.public_key,
+                pni_private_key: Some(pni_identity_key_pair.private_key),
+                pni_public_key: Some(pni_identity_key_pair.public_key),
+                profile_key,
+            },
+        };
+
+        manager.config_store.save_state(&manager.state)?;
+
+        if let Err(e) = manager.register_pre_keys().await {
+            // clear the entire store on any error, there's no possible recovery here
+            manager.config_store.clear_registration()?;
+            Err(e)
+        } else {
+            Ok(manager)
+        }
+    }
+}

--- a/presage/src/manager/confirmation.rs
+++ b/presage/src/manager/confirmation.rs
@@ -28,7 +28,7 @@ pub struct Confirmation {
     pub(crate) session_id: String,
 }
 
-impl<C: Store> Manager<C, Confirmation> {
+impl<S: Store> Manager<S, Confirmation> {
     /// Confirm a newly registered account using the code you
     /// received by SMS or phone call.
     ///
@@ -37,7 +37,7 @@ impl<C: Store> Manager<C, Confirmation> {
     pub async fn confirm_verification_code(
         self,
         confirmation_code: impl AsRef<str>,
-    ) -> Result<Manager<C, Registered>, Error<C::Error>> {
+    ) -> Result<Manager<S, Registered>, Error<S::Error>> {
         trace!("confirming verification code");
 
         let registration_id = generate_registration_id(&mut StdRng::from_entropy());

--- a/presage/src/manager/confirmation.rs
+++ b/presage/src/manager/confirmation.rs
@@ -120,7 +120,7 @@ impl<C: Store> Manager<C, Confirmation> {
 
         let mut manager = Manager {
             rng,
-            config_store: self.config_store,
+            store: self.store,
             state: Registered {
                 push_service_cache: CacheCell::default(),
                 identified_websocket: Default::default(),
@@ -146,11 +146,11 @@ impl<C: Store> Manager<C, Confirmation> {
             },
         };
 
-        manager.config_store.save_state(&manager.state)?;
+        manager.store.save_state(&manager.state)?;
 
         if let Err(e) = manager.register_pre_keys().await {
             // clear the entire store on any error, there's no possible recovery here
-            manager.config_store.clear_registration()?;
+            manager.store.clear_registration()?;
             Err(e)
         } else {
             Ok(manager)

--- a/presage/src/manager/confirmation.rs
+++ b/presage/src/manager/confirmation.rs
@@ -13,6 +13,7 @@ use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
 
 use crate::cache::CacheCell;
+use crate::manager::registered::RegistrationData;
 use crate::store::Store;
 use crate::{Error, Manager};
 
@@ -126,27 +127,29 @@ impl<S: Store> Manager<S, Confirmation> {
                 identified_websocket: Default::default(),
                 unidentified_websocket: Default::default(),
                 unidentified_sender_certificate: Default::default(),
-                signal_servers: self.state.signal_servers,
-                device_name: None,
-                phone_number,
-                service_ids: ServiceIds {
-                    aci: registered.uuid,
-                    pni: registered.pni,
+                data: RegistrationData {
+                    signal_servers: self.state.signal_servers,
+                    device_name: None,
+                    phone_number,
+                    service_ids: ServiceIds {
+                        aci: registered.uuid,
+                        pni: registered.pni,
+                    },
+                    password,
+                    signaling_key,
+                    device_id: None,
+                    registration_id,
+                    pni_registration_id: Some(pni_registration_id),
+                    aci_private_key: aci_identity_key_pair.private_key,
+                    aci_public_key: aci_identity_key_pair.public_key,
+                    pni_private_key: Some(pni_identity_key_pair.private_key),
+                    pni_public_key: Some(pni_identity_key_pair.public_key),
+                    profile_key,
                 },
-                password,
-                signaling_key,
-                device_id: None,
-                registration_id,
-                pni_registration_id: Some(pni_registration_id),
-                aci_private_key: aci_identity_key_pair.private_key,
-                aci_public_key: aci_identity_key_pair.public_key,
-                pni_private_key: Some(pni_identity_key_pair.private_key),
-                pni_public_key: Some(pni_identity_key_pair.public_key),
-                profile_key,
             },
         };
 
-        manager.store.save_state(&manager.state)?;
+        manager.store.save_registration_data(&manager.state.data)?;
 
         if let Err(e) = manager.register_pre_keys().await {
             // clear the entire store on any error, there's no possible recovery here

--- a/presage/src/manager/linking.rs
+++ b/presage/src/manager/linking.rs
@@ -1,0 +1,167 @@
+use futures::channel::{mpsc, oneshot};
+use futures::{future, StreamExt};
+use libsignal_service::configuration::{ServiceConfiguration, SignalServers};
+use libsignal_service::provisioning::{LinkingManager, SecondaryDeviceProvisioning};
+use libsignal_service::push_service::DeviceId;
+use libsignal_service::zkgroup::profiles::ProfileKey;
+use libsignal_service_hyper::push_service::HyperPushService;
+use log::warn;
+use rand::distributions::{Alphanumeric, DistString};
+use rand::rngs::StdRng;
+use rand::{RngCore, SeedableRng};
+use url::Url;
+
+use crate::cache::CacheCell;
+use crate::store::Store;
+use crate::{Error, Manager};
+
+use super::Registered;
+
+/// Manager state where it is possible to link a new secondary device
+pub struct Linking;
+
+impl<C: Store> Manager<C, Linking> {
+    /// Links this client as a secondary device from the device used to register the account (usually a phone).
+    /// The URL to present to the user will be sent in the channel given as the argument.
+    ///
+    /// ```no_run
+    /// use futures::{channel::oneshot, future, StreamExt};
+    /// use presage::libsignal_service::configuration::SignalServers;
+    /// use presage::Manager;
+    /// use presage_store_sled::{MigrationConflictStrategy, SledStore};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let config_store =
+    ///         SledStore::open("/tmp/presage-example", MigrationConflictStrategy::Drop)?;
+    ///
+    ///     let (mut tx, mut rx) = oneshot::channel();
+    ///     let (manager, err) = future::join(
+    ///         Manager::link_secondary_device(
+    ///             config_store,
+    ///             SignalServers::Production,
+    ///             "my-linked-client".into(),
+    ///             tx,
+    ///         ),
+    ///         async move {
+    ///             match rx.await {
+    ///                 Ok(url) => println!("Show URL {} as QR code to user", url),
+    ///                 Err(e) => println!("Error linking device: {}", e),
+    ///             }
+    ///         },
+    ///     )
+    ///     .await;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn link_secondary_device(
+        mut config_store: C,
+        signal_servers: SignalServers,
+        device_name: String,
+        provisioning_link_channel: oneshot::Sender<Url>,
+    ) -> Result<Manager<C, Registered>, Error<C::Error>> {
+        // clear the database: the moment we start the process, old API credentials are invalidated
+        // and you won't be able to use this client anyways
+        config_store.clear_registration()?;
+
+        // generate a random alphanumeric 24 chars password
+        let mut rng = StdRng::from_entropy();
+        let password = Alphanumeric.sample_string(&mut rng, 24);
+
+        // generate a 52 bytes signaling key
+        let mut signaling_key = [0u8; 52];
+        rng.fill_bytes(&mut signaling_key);
+
+        let service_configuration: ServiceConfiguration = signal_servers.into();
+        let push_service =
+            HyperPushService::new(service_configuration, None, crate::USER_AGENT.to_string());
+
+        let mut linking_manager: LinkingManager<HyperPushService> =
+            LinkingManager::new(push_service, password.clone());
+
+        let (tx, mut rx) = mpsc::channel(1);
+
+        let (wait_for_qrcode_scan, registration) = future::join(
+            linking_manager.provision_secondary_device(&mut rng, signaling_key, tx),
+            async move {
+                if let Some(SecondaryDeviceProvisioning::Url(url)) = rx.next().await {
+                    log::info!("generating qrcode from provisioning link: {}", &url);
+                    if provisioning_link_channel.send(url).is_err() {
+                        return Err(Error::LinkError);
+                    }
+                } else {
+                    return Err(Error::LinkError);
+                }
+
+                if let Some(SecondaryDeviceProvisioning::NewDeviceRegistration {
+                    phone_number,
+                    device_id: DeviceId { device_id },
+                    registration_id,
+                    pni_registration_id,
+                    profile_key,
+                    service_ids,
+                    aci_private_key,
+                    aci_public_key,
+                    pni_private_key,
+                    pni_public_key,
+                }) = rx.next().await
+                {
+                    log::info!("successfully registered device {}", &service_ids);
+                    Ok(Registered {
+                        push_service_cache: CacheCell::default(),
+                        identified_websocket: Default::default(),
+                        unidentified_websocket: Default::default(),
+                        unidentified_sender_certificate: Default::default(),
+                        signal_servers,
+                        device_name: Some(device_name),
+                        phone_number,
+                        service_ids,
+                        signaling_key,
+                        password,
+                        device_id: Some(device_id),
+                        registration_id,
+                        pni_registration_id: Some(pni_registration_id),
+                        aci_public_key,
+                        aci_private_key,
+                        pni_public_key: Some(pni_public_key),
+                        pni_private_key: Some(pni_private_key),
+                        profile_key: ProfileKey::create(
+                            profile_key.try_into().expect("32 bytes for profile key"),
+                        ),
+                    })
+                } else {
+                    Err(Error::NoProvisioningMessageReceived)
+                }
+            },
+        )
+        .await;
+
+        wait_for_qrcode_scan?;
+
+        let mut manager = Manager {
+            rng,
+            config_store,
+            state: registration?,
+        };
+
+        manager.config_store.save_state(&manager.state)?;
+
+        match (
+            manager.register_pre_keys().await,
+            manager.set_account_attributes().await,
+            manager.sync_contacts().await,
+        ) {
+            (Err(e), _, _) | (_, Err(e), _) => {
+                // clear the entire store on any error, there's no possible recovery here
+                manager.config_store.clear_registration()?;
+                Err(e)
+            }
+            (_, _, Err(e)) => {
+                warn!("failed to synchronize contacts: {e}");
+                Ok(manager)
+            }
+            _ => Ok(manager),
+        }
+    }
+}

--- a/presage/src/manager/linking.rs
+++ b/presage/src/manager/linking.rs
@@ -5,7 +5,7 @@ use libsignal_service::provisioning::{LinkingManager, SecondaryDeviceProvisionin
 use libsignal_service::push_service::DeviceId;
 use libsignal_service::zkgroup::profiles::ProfileKey;
 use libsignal_service_hyper::push_service::HyperPushService;
-use log::warn;
+use log::{info, warn};
 use rand::distributions::{Alphanumeric, DistString};
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
@@ -86,7 +86,7 @@ impl<C: Store> Manager<C, Linking> {
             linking_manager.provision_secondary_device(&mut rng, signaling_key, tx),
             async move {
                 if let Some(SecondaryDeviceProvisioning::Url(url)) = rx.next().await {
-                    log::info!("generating qrcode from provisioning link: {}", &url);
+                    info!("generating qrcode from provisioning link: {}", &url);
                     if provisioning_link_channel.send(url).is_err() {
                         return Err(Error::LinkError);
                     }
@@ -107,7 +107,7 @@ impl<C: Store> Manager<C, Linking> {
                     pni_public_key,
                 }) = rx.next().await
                 {
-                    log::info!("successfully registered device {}", &service_ids);
+                    info!("successfully registered device {}", &service_ids);
                     Ok(Registered {
                         push_service_cache: CacheCell::default(),
                         identified_websocket: Default::default(),

--- a/presage/src/manager/linking.rs
+++ b/presage/src/manager/linking.rs
@@ -20,7 +20,7 @@ use super::Registered;
 /// Manager state where it is possible to link a new secondary device
 pub struct Linking;
 
-impl<C: Store> Manager<C, Linking> {
+impl<S: Store> Manager<S, Linking> {
     /// Links this client as a secondary device from the device used to register the account (usually a phone).
     /// The URL to present to the user will be sent in the channel given as the argument.
     ///
@@ -56,11 +56,11 @@ impl<C: Store> Manager<C, Linking> {
     /// }
     /// ```
     pub async fn link_secondary_device(
-        mut store: C,
+        mut store: S,
         signal_servers: SignalServers,
         device_name: String,
         provisioning_link_channel: oneshot::Sender<Url>,
-    ) -> Result<Manager<C, Registered>, Error<C::Error>> {
+    ) -> Result<Manager<S, Registered>, Error<S::Error>> {
         // clear the database: the moment we start the process, old API credentials are invalidated
         // and you won't be able to use this client anyways
         store.clear_registration()?;

--- a/presage/src/manager/mod.rs
+++ b/presage/src/manager/mod.rs
@@ -1,0 +1,95 @@
+//! Signal manager and its states
+
+mod confirmation;
+mod linking;
+mod registered;
+mod registration;
+
+use std::fmt;
+
+use rand::rngs::StdRng;
+
+pub use self::confirmation::Confirmation;
+pub use self::linking::Linking;
+pub use self::registered::{ReceivingMode, Registered};
+pub use self::registration::{Registration, RegistrationOptions};
+
+/// Signal manager
+///
+/// The manager is parametrized over the [`crate::store::Store`] which stores the configuration, keys and
+/// optionally messages; and over the type state which describes what is the current state of the
+/// manager: in registration, linking, TODO
+///
+/// Depending on the state specific methods are available or not.
+#[derive(Clone)]
+pub struct Manager<Store, State> {
+    /// Implementation of a config-store to give to libsignal
+    config_store: Store,
+    /// Part of the manager which is persisted in the store.
+    state: State,
+    /// Random number generator
+    rng: StdRng,
+}
+
+impl<Store, State: fmt::Debug> fmt::Debug for Manager<Store, State> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Manager")
+            .field("state", &self.state)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::engine::general_purpose;
+    use base64::Engine;
+    use libsignal_service::prelude::ProfileKey;
+    use libsignal_service::protocol::KeyPair;
+    use rand::RngCore;
+    use serde_json::json;
+
+    use crate::manager::Registered;
+
+    #[test]
+    fn test_state_before_pni() {
+        let mut rng = rand::thread_rng();
+        let key_pair = KeyPair::generate(&mut rng);
+        let mut profile_key = [0u8; 32];
+        rng.fill_bytes(&mut profile_key);
+        let profile_key = ProfileKey::generate(profile_key);
+        let mut signaling_key = [0u8; 52];
+        rng.fill_bytes(&mut signaling_key);
+
+        // this is before public_key and private_key were renamed to aci_public_key and aci_private_key
+        // and pni_public_key + pni_private_key were added
+        let previous_state = json!({
+          "signal_servers": "Production",
+          "device_name": "Test",
+          "phone_number": {
+            "code": {
+              "value": 1,
+              "source": "plus"
+            },
+            "national": {
+              "value": 5550199,
+              "zeros": 0
+            },
+            "extension": null,
+            "carrier": null
+          },
+          "uuid": "ff9a89d9-8052-4af0-a91d-2a0dfa0c6b95",
+          "password": "HelloWorldOfPasswords",
+          "signaling_key": general_purpose::STANDARD.encode(signaling_key),
+          "device_id": 42,
+          "registration_id": 64,
+          "private_key": general_purpose::STANDARD.encode(key_pair.private_key.serialize()),
+          "public_key": general_purpose::STANDARD.encode(key_pair.public_key.serialize()),
+          "profile_key": general_purpose::STANDARD.encode(profile_key.get_bytes()),
+        });
+
+        let state: Registered = serde_json::from_value(previous_state).expect("should deserialize");
+        assert_eq!(state.aci_public_key, key_pair.public_key);
+        assert!(state.aci_private_key == key_pair.private_key);
+        assert!(state.pni_public_key.is_none());
+    }
+}

--- a/presage/src/manager/mod.rs
+++ b/presage/src/manager/mod.rs
@@ -11,7 +11,7 @@ use rand::rngs::StdRng;
 
 pub use self::confirmation::Confirmation;
 pub use self::linking::Linking;
-pub use self::registered::{ReceivingMode, Registered};
+pub use self::registered::{ReceivingMode, Registered, RegistrationData};
 pub use self::registration::{Registration, RegistrationOptions};
 
 /// Signal manager
@@ -48,7 +48,7 @@ mod tests {
     use rand::RngCore;
     use serde_json::json;
 
-    use crate::manager::Registered;
+    use crate::manager::RegistrationData;
 
     #[test]
     fn test_state_before_pni() {
@@ -87,9 +87,10 @@ mod tests {
           "profile_key": general_purpose::STANDARD.encode(profile_key.get_bytes()),
         });
 
-        let state: Registered = serde_json::from_value(previous_state).expect("should deserialize");
-        assert_eq!(state.aci_public_key, key_pair.public_key);
-        assert!(state.aci_private_key == key_pair.private_key);
-        assert!(state.pni_public_key.is_none());
+        let data: RegistrationData =
+            serde_json::from_value(previous_state).expect("should deserialize");
+        assert_eq!(data.aci_public_key, key_pair.public_key);
+        assert!(data.aci_private_key == key_pair.private_key);
+        assert!(data.pni_public_key.is_none());
     }
 }

--- a/presage/src/manager/mod.rs
+++ b/presage/src/manager/mod.rs
@@ -23,8 +23,8 @@ pub use self::registration::{Registration, RegistrationOptions};
 /// Depending on the state specific methods are available or not.
 #[derive(Clone)]
 pub struct Manager<Store, State> {
-    /// Implementation of a config-store to give to libsignal
-    config_store: Store,
+    /// Implementation of a metadata and messages store
+    store: Store,
     /// Part of the manager which is persisted in the store.
     state: State,
     /// Random number generator

--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -705,13 +705,8 @@ impl<S: Store> Manager<S, Registered> {
         let mut sender = self.new_message_sender().await?;
 
         let mut groups_manager = self.groups_manager()?;
-        let Some(group) = upsert_group(
-            &self.store,
-            &mut groups_manager,
-            master_key_bytes,
-            &0,
-        )
-        .await?
+        let Some(group) =
+            upsert_group(&self.store, &mut groups_manager, master_key_bytes, &0).await?
         else {
             return Err(Error::UnknownGroup);
         };

--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -886,28 +886,6 @@ impl<C: Store> Manager<C, Registered> {
             },
         }
     }
-
-    #[deprecated = "use Manager::contact_by_id"]
-    pub fn get_contacts(
-        &self,
-    ) -> Result<impl Iterator<Item = Result<Contact, Error<C::Error>>>, Error<C::Error>> {
-        self.contacts()
-    }
-
-    #[deprecated = "use Manager::contact_by_id"]
-    pub fn get_contact_by_id(&self, id: Uuid) -> Result<Option<Contact>, Error<C::Error>> {
-        self.contact_by_id(&id)
-    }
-
-    #[deprecated = "use Manager::groups"]
-    pub fn get_groups(&self) -> Result<C::GroupsIter, Error<C::Error>> {
-        self.groups()
-    }
-
-    #[deprecated = "use Manager::group"]
-    pub fn get_group(&self, master_key_bytes: &[u8]) -> Result<Option<Group>, Error<C::Error>> {
-        self.group(master_key_bytes)
-    }
 }
 
 /// The mode receiving messages stream

--- a/presage/src/manager/registration.rs
+++ b/presage/src/manager/registration.rs
@@ -43,11 +43,11 @@ impl<C: Store> Manager<C, Registration> {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let config_store =
+    ///     let store =
     ///         SledStore::open("/tmp/presage-example", MigrationConflictStrategy::Drop)?;
     ///
     ///     let manager = Manager::register(
-    ///         config_store,
+    ///         store,
     ///         RegistrationOptions {
     ///             signal_servers: SignalServers::Production,
     ///             phone_number: PhoneNumber::from_str("+16137827274")?,
@@ -62,7 +62,7 @@ impl<C: Store> Manager<C, Registration> {
     /// }
     /// ```
     pub async fn register(
-        mut config_store: C,
+        mut store: C,
         registration_options: RegistrationOptions<'_>,
     ) -> Result<Manager<C, Confirmation>, Error<C::Error>> {
         let RegistrationOptions {
@@ -74,11 +74,11 @@ impl<C: Store> Manager<C, Registration> {
         } = registration_options;
 
         // check if we are already registered
-        if !force && config_store.is_registered() {
+        if !force && store.is_registered() {
             return Err(Error::AlreadyRegisteredError);
         }
 
-        config_store.clear_registration()?;
+        store.clear_registration()?;
 
         // generate a random alphanumeric 24 chars password
         let mut rng = StdRng::from_entropy();
@@ -129,7 +129,7 @@ impl<C: Store> Manager<C, Registration> {
             .await?;
 
         let manager = Manager {
-            config_store,
+            store,
             state: Confirmation {
                 signal_servers,
                 phone_number,

--- a/presage/src/manager/registration.rs
+++ b/presage/src/manager/registration.rs
@@ -25,7 +25,7 @@ pub struct RegistrationOptions<'a> {
 /// Manager state where it is possible to register a new main device
 pub struct Registration;
 
-impl<C: Store> Manager<C, Registration> {
+impl<S: Store> Manager<S, Registration> {
     /// Registers a new account with a phone number (and some options).
     ///
     /// The returned value is a [confirmation manager](Manager::confirm_verification_code) which you then
@@ -62,9 +62,9 @@ impl<C: Store> Manager<C, Registration> {
     /// }
     /// ```
     pub async fn register(
-        mut store: C,
+        mut store: S,
         registration_options: RegistrationOptions<'_>,
-    ) -> Result<Manager<C, Confirmation>, Error<C::Error>> {
+    ) -> Result<Manager<S, Confirmation>, Error<S::Error>> {
         let RegistrationOptions {
             signal_servers,
             phone_number,

--- a/presage/src/manager/registration.rs
+++ b/presage/src/manager/registration.rs
@@ -1,0 +1,144 @@
+use libsignal_service::configuration::{ServiceConfiguration, SignalServers};
+use libsignal_service::prelude::phonenumber::PhoneNumber;
+use libsignal_service::push_service::{PushService, VerificationTransport};
+use libsignal_service_hyper::push_service::HyperPushService;
+use log::trace;
+use rand::distributions::{Alphanumeric, DistString};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+use crate::store::Store;
+use crate::{Error, Manager};
+
+use super::Confirmation;
+
+/// Options when registering a new main device
+#[derive(Debug)]
+pub struct RegistrationOptions<'a> {
+    pub signal_servers: SignalServers,
+    pub phone_number: PhoneNumber,
+    pub use_voice_call: bool,
+    pub captcha: Option<&'a str>,
+    pub force: bool,
+}
+
+/// Manager state where it is possible to register a new main device
+pub struct Registration;
+
+impl<C: Store> Manager<C, Registration> {
+    /// Registers a new account with a phone number (and some options).
+    ///
+    /// The returned value is a [confirmation manager](Manager::confirm_verification_code) which you then
+    /// have to use to send the confirmation code.
+    ///
+    /// ```no_run
+    /// use std::str::FromStr;
+    ///
+    /// use presage::libsignal_service::{
+    ///     configuration::SignalServers, prelude::phonenumber::PhoneNumber,
+    /// };
+    /// use presage::manager::RegistrationOptions;
+    /// use presage::Manager;
+    /// use presage_store_sled::{MigrationConflictStrategy, SledStore};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let config_store =
+    ///         SledStore::open("/tmp/presage-example", MigrationConflictStrategy::Drop)?;
+    ///
+    ///     let manager = Manager::register(
+    ///         config_store,
+    ///         RegistrationOptions {
+    ///             signal_servers: SignalServers::Production,
+    ///             phone_number: PhoneNumber::from_str("+16137827274")?,
+    ///             use_voice_call: false,
+    ///             captcha: None,
+    ///             force: false,
+    ///         },
+    ///     )
+    ///     .await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn register(
+        mut config_store: C,
+        registration_options: RegistrationOptions<'_>,
+    ) -> Result<Manager<C, Confirmation>, Error<C::Error>> {
+        let RegistrationOptions {
+            signal_servers,
+            phone_number,
+            use_voice_call,
+            captcha,
+            force,
+        } = registration_options;
+
+        // check if we are already registered
+        if !force && config_store.is_registered() {
+            return Err(Error::AlreadyRegisteredError);
+        }
+
+        config_store.clear_registration()?;
+
+        // generate a random alphanumeric 24 chars password
+        let mut rng = StdRng::from_entropy();
+        let password = Alphanumeric.sample_string(&mut rng, 24);
+
+        let service_configuration: ServiceConfiguration = signal_servers.into();
+        let mut push_service =
+            HyperPushService::new(service_configuration, None, crate::USER_AGENT.to_string());
+
+        trace!("creating registration verification session");
+
+        let phone_number_string = phone_number.to_string();
+        let mut session = push_service
+            .create_verification_session(&phone_number_string, None, None, None)
+            .await?;
+
+        if !session.allowed_to_request_code {
+            if session.captcha_required() {
+                trace!("captcha required");
+                if captcha.is_none() {
+                    return Err(Error::CaptchaRequired);
+                }
+                session = push_service
+                    .patch_verification_session(&session.id, None, None, None, captcha, None)
+                    .await?
+            }
+            if session.push_challenge_required() {
+                return Err(Error::PushChallengeRequired);
+            }
+        }
+
+        if !session.allowed_to_request_code {
+            return Err(Error::RequestingCodeForbidden(session));
+        }
+
+        trace!("requesting verification code");
+
+        session = push_service
+            .request_verification_code(
+                &session.id,
+                crate::USER_AGENT,
+                if use_voice_call {
+                    VerificationTransport::Voice
+                } else {
+                    VerificationTransport::Sms
+                },
+            )
+            .await?;
+
+        let manager = Manager {
+            config_store,
+            state: Confirmation {
+                signal_servers,
+                phone_number,
+                password,
+                session_id: session.id,
+            },
+            rng,
+        };
+
+        Ok(manager)
+    }
+}

--- a/presage/src/store.rs
+++ b/presage/src/store.rs
@@ -89,6 +89,14 @@ pub trait ContentsStore {
         message: Content,
     ) -> Result<(), Self::ContentsStoreError>;
 
+    /// Delete a single message, identified by its received timestamp from a thread.
+    /// Useful when you want to delete a message locally only.
+    fn delete_message(
+        &mut self,
+        thread: &Thread,
+        timestamp: u64,
+    ) -> Result<bool, Self::ContentsStoreError>;
+
     /// Retrieve a message from a [Thread] by its timestamp.
     fn message(
         &self,

--- a/presage/src/store.rs
+++ b/presage/src/store.rs
@@ -89,14 +89,6 @@ pub trait ContentsStore {
         message: Content,
     ) -> Result<(), Self::ContentsStoreError>;
 
-    /// Delete a single message, identified by its received timestamp from a thread.
-    #[deprecated = "message deletion is now handled internally"]
-    fn delete_message(
-        &mut self,
-        thread: &Thread,
-        timestamp: u64,
-    ) -> Result<bool, Self::ContentsStoreError>;
-
     /// Retrieve a message from a [Thread] by its timestamp.
     fn message(
         &self,

--- a/presage/src/store.rs
+++ b/presage/src/store.rs
@@ -18,7 +18,7 @@ use libsignal_service::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::manager::Registered;
+use crate::manager::RegistrationData;
 
 /// An error trait implemented by store error types
 pub trait StoreError: std::error::Error + Sync + Send + 'static {}
@@ -28,10 +28,13 @@ pub trait StateStore {
     type StateStoreError: StoreError;
 
     /// Load registered (or linked) state
-    fn load_state(&self) -> Result<Option<Registered>, Self::StateStoreError>;
+    fn load_registration_data(&self) -> Result<Option<RegistrationData>, Self::StateStoreError>;
 
     /// Save registered (or linked) state
-    fn save_state(&mut self, state: &Registered) -> Result<(), Self::StateStoreError>;
+    fn save_registration_data(
+        &mut self,
+        state: &RegistrationData,
+    ) -> Result<(), Self::StateStoreError>;
 
     /// Returns whether this store contains registration data or not
     fn is_registered(&self) -> bool;

--- a/presage/src/store.rs
+++ b/presage/src/store.rs
@@ -43,20 +43,20 @@ pub trait StateStore {
 /// Stores the keys published ahead of time, pre-keys
 ///
 /// <https://signal.org/docs/specifications/x3dh/>
-pub trait PrekeysStore {
-    type PrekeysStoreError: StoreError;
+pub trait PreKeyStoreExt {
+    type PreKeyStoreExtError: StoreError;
 
-    fn pre_keys_offset_id(&self) -> Result<u32, Self::PrekeysStoreError>;
+    fn pre_keys_offset_id(&self) -> Result<u32, Self::PreKeyStoreExtError>;
 
-    fn set_pre_keys_offset_id(&mut self, id: u32) -> Result<(), Self::PrekeysStoreError>;
+    fn set_pre_keys_offset_id(&mut self, id: u32) -> Result<(), Self::PreKeyStoreExtError>;
 
-    fn next_signed_pre_key_id(&self) -> Result<u32, Self::PrekeysStoreError>;
+    fn next_signed_pre_key_id(&self) -> Result<u32, Self::PreKeyStoreExtError>;
 
-    fn next_pq_pre_key_id(&self) -> Result<u32, Self::PrekeysStoreError>;
+    fn next_pq_pre_key_id(&self) -> Result<u32, Self::PreKeyStoreExtError>;
 
-    fn set_next_signed_pre_key_id(&mut self, id: u32) -> Result<(), Self::PrekeysStoreError>;
+    fn set_next_signed_pre_key_id(&mut self, id: u32) -> Result<(), Self::PreKeyStoreExtError>;
 
-    fn set_next_pq_pre_key_id(&mut self, id: u32) -> Result<(), Self::PrekeysStoreError>;
+    fn set_next_pq_pre_key_id(&mut self, id: u32) -> Result<(), Self::PreKeyStoreExtError>;
 }
 
 /// Stores messages, contacts, groups and profiles
@@ -190,7 +190,7 @@ pub trait ContentsStore {
 /// The manager store trait combining all other stores into a single one
 pub trait Store:
     StateStore<StateStoreError = Self::Error>
-    + PrekeysStore<PrekeysStoreError = Self::Error>
+    + PreKeyStoreExt<PreKeyStoreExtError = Self::Error>
     + ContentsStore<ContentsStoreError = Self::Error>
     + ProtocolStore
     + SenderKeyStore

--- a/presage/src/store.rs
+++ b/presage/src/store.rs
@@ -1,6 +1,7 @@
+//! Traits that are used by the manager for storing the data.
+
 use std::{fmt, ops::RangeBounds};
 
-use crate::{manager::Registered, GroupMasterKeyBytes};
 use libsignal_service::{
     content::ContentBody,
     groups_v2::Group,
@@ -12,78 +13,107 @@ use libsignal_service::{
     },
     protocol::{ProtocolStore, SenderKeyStore},
     session_store::SessionStoreExt,
+    zkgroup::GroupMasterKeyBytes,
     Profile,
 };
 use serde::{Deserialize, Serialize};
 
+use crate::manager::Registered;
+
+/// An error trait implemented by store error types
 pub trait StoreError: std::error::Error + Sync + Send + 'static {}
 
-pub trait Store: ProtocolStore + SenderKeyStore + SessionStoreExt + Sync + Clone {
-    type Error: StoreError;
-
-    type ContactsIter: Iterator<Item = Result<Contact, Self::Error>>;
-    type GroupsIter: Iterator<Item = Result<(GroupMasterKeyBytes, Group), Self::Error>>;
-    type MessagesIter: Iterator<Item = Result<Content, Self::Error>>;
-
-    /// State
+/// Stores the registered state of the manager
+pub trait StateStore {
+    type StateStoreError: StoreError;
 
     /// Load registered (or linked) state
-    fn load_state(&self) -> Result<Option<Registered>, Self::Error>;
+    fn load_state(&self) -> Result<Option<Registered>, Self::StateStoreError>;
 
     /// Save registered (or linked) state
-    fn save_state(&mut self, state: &Registered) -> Result<(), Self::Error>;
+    fn save_state(&mut self, state: &Registered) -> Result<(), Self::StateStoreError>;
 
     /// Returns whether this store contains registration data or not
     fn is_registered(&self) -> bool;
 
     /// Clear registration data (including keys), but keep received messages, groups and contacts.
-    fn clear_registration(&mut self) -> Result<(), Self::Error>;
+    fn clear_registration(&mut self) -> Result<(), Self::StateStoreError>;
+}
 
-    /// Clear the entire store: this can be useful when resetting an existing client.
-    fn clear(&mut self) -> Result<(), Self::Error>;
+/// Stores the keys published ahead of time, pre-keys
+///
+/// <https://signal.org/docs/specifications/x3dh/>
+pub trait PrekeysStore {
+    type PrekeysStoreError: StoreError;
 
-    /// Pre-keys
+    fn pre_keys_offset_id(&self) -> Result<u32, Self::PrekeysStoreError>;
 
-    fn pre_keys_offset_id(&self) -> Result<u32, Self::Error>;
+    fn set_pre_keys_offset_id(&mut self, id: u32) -> Result<(), Self::PrekeysStoreError>;
 
-    fn set_pre_keys_offset_id(&mut self, id: u32) -> Result<(), Self::Error>;
+    fn next_signed_pre_key_id(&self) -> Result<u32, Self::PrekeysStoreError>;
 
-    fn next_signed_pre_key_id(&self) -> Result<u32, Self::Error>;
+    fn next_pq_pre_key_id(&self) -> Result<u32, Self::PrekeysStoreError>;
 
-    fn next_pq_pre_key_id(&self) -> Result<u32, Self::Error>;
+    fn set_next_signed_pre_key_id(&mut self, id: u32) -> Result<(), Self::PrekeysStoreError>;
 
-    fn set_next_signed_pre_key_id(&mut self, id: u32) -> Result<(), Self::Error>;
+    fn set_next_pq_pre_key_id(&mut self, id: u32) -> Result<(), Self::PrekeysStoreError>;
+}
 
-    fn set_next_pq_pre_key_id(&mut self, id: u32) -> Result<(), Self::Error>;
+/// Stores messages, contacts, groups and profiles
+pub trait ContentsStore {
+    type ContentsStoreError: StoreError;
 
-    /// Messages
+    /// Iterator over the contacts
+    type ContactsIter: Iterator<Item = Result<Contact, Self::ContentsStoreError>>;
 
-    // Clear all stored messages.
-    fn clear_messages(&mut self) -> Result<(), Self::Error>;
+    /// Iterator over all stored groups
+    ///
+    /// Each items is a tuple consisting of the group master key and its corresponding data.
+    type GroupsIter: Iterator<Item = Result<(GroupMasterKeyBytes, Group), Self::ContentsStoreError>>;
 
-    // Clear the messages in a thread.
-    fn clear_thread(&mut self, thread: &Thread) -> Result<(), Self::Error>;
+    /// Iterator over all stored messages
+    type MessagesIter: Iterator<Item = Result<Content, Self::ContentsStoreError>>;
+
+    // Messages
+
+    /// Clear all stored messages.
+    fn clear_messages(&mut self) -> Result<(), Self::ContentsStoreError>;
+
+    /// Clear the messages in a thread.
+    fn clear_thread(&mut self, thread: &Thread) -> Result<(), Self::ContentsStoreError>;
 
     /// Save a message in a [Thread] identified by a timestamp.
-    fn save_message(&mut self, thread: &Thread, message: Content) -> Result<(), Self::Error>;
+    fn save_message(
+        &mut self,
+        thread: &Thread,
+        message: Content,
+    ) -> Result<(), Self::ContentsStoreError>;
 
     /// Delete a single message, identified by its received timestamp from a thread.
     #[deprecated = "message deletion is now handled internally"]
-    fn delete_message(&mut self, thread: &Thread, timestamp: u64) -> Result<bool, Self::Error>;
+    fn delete_message(
+        &mut self,
+        thread: &Thread,
+        timestamp: u64,
+    ) -> Result<bool, Self::ContentsStoreError>;
 
     /// Retrieve a message from a [Thread] by its timestamp.
-    fn message(&self, thread: &Thread, timestamp: u64) -> Result<Option<Content>, Self::Error>;
+    fn message(
+        &self,
+        thread: &Thread,
+        timestamp: u64,
+    ) -> Result<Option<Content>, Self::ContentsStoreError>;
 
     /// Retrieve all messages from a [Thread] within a range in time
     fn messages(
         &self,
         thread: &Thread,
         range: impl RangeBounds<u64>,
-    ) -> Result<Self::MessagesIter, Self::Error>;
+    ) -> Result<Self::MessagesIter, Self::ContentsStoreError>;
 
     /// Get the expire timer from a [Thread], which corresponds to either [Contact::expire_timer]
     /// or [Group::disappearing_messages_timer].
-    fn expire_timer(&self, thread: &Thread) -> Result<Option<u32>, Self::Error> {
+    fn expire_timer(&self, thread: &Thread) -> Result<Option<u32>, Self::ContentsStoreError> {
         match thread {
             Thread::Contact(uuid) => Ok(self.contact_by_id(*uuid)?.map(|c| c.expire_timer)),
             Thread::Group(key) => Ok(self
@@ -93,41 +123,53 @@ pub trait Store: ProtocolStore + SenderKeyStore + SessionStoreExt + Sync + Clone
         }
     }
 
-    /// Contacts
+    // Contacts
 
     /// Clear all saved synchronized contact data
-    fn clear_contacts(&mut self) -> Result<(), Self::Error>;
+    fn clear_contacts(&mut self) -> Result<(), Self::ContentsStoreError>;
 
     /// Replace all contact data
-    fn save_contacts(&mut self, contacts: impl Iterator<Item = Contact>)
-        -> Result<(), Self::Error>;
+    fn save_contacts(
+        &mut self,
+        contacts: impl Iterator<Item = Contact>,
+    ) -> Result<(), Self::ContentsStoreError>;
 
     /// Get an iterator on all stored (synchronized) contacts
-    fn contacts(&self) -> Result<Self::ContactsIter, Self::Error>;
+    fn contacts(&self) -> Result<Self::ContactsIter, Self::ContentsStoreError>;
 
     /// Get contact data for a single user by its [Uuid].
-    fn contact_by_id(&self, id: Uuid) -> Result<Option<Contact>, Self::Error>;
+    fn contact_by_id(&self, id: Uuid) -> Result<Option<Contact>, Self::ContentsStoreError>;
 
     /// Delete all cached group data
-    fn clear_groups(&mut self) -> Result<(), Self::Error>;
+    fn clear_groups(&mut self) -> Result<(), Self::ContentsStoreError>;
 
     /// Save a group in the cache
-    fn save_group(&self, master_key: GroupMasterKeyBytes, group: &Group)
-        -> Result<(), Self::Error>;
+    fn save_group(
+        &self,
+        master_key: GroupMasterKeyBytes,
+        group: &Group,
+    ) -> Result<(), Self::ContentsStoreError>;
 
     /// Get an iterator on all cached groups
-    fn groups(&self) -> Result<Self::GroupsIter, Self::Error>;
+    fn groups(&self) -> Result<Self::GroupsIter, Self::ContentsStoreError>;
 
     /// Retrieve a single unencrypted group indexed by its `[GroupMasterKeyBytes]`
-    fn group(&self, master_key: GroupMasterKeyBytes) -> Result<Option<Group>, Self::Error>;
+    fn group(
+        &self,
+        master_key: GroupMasterKeyBytes,
+    ) -> Result<Option<Group>, Self::ContentsStoreError>;
 
-    /// Profiles
+    // Profiles
 
     /// Insert or update the profile key of a contact
-    fn upsert_profile_key(&mut self, uuid: &Uuid, key: ProfileKey) -> Result<bool, Self::Error>;
+    fn upsert_profile_key(
+        &mut self,
+        uuid: &Uuid,
+        key: ProfileKey,
+    ) -> Result<bool, Self::ContentsStoreError>;
 
     /// Get the profile key for a contact
-    fn profile_key(&self, uuid: &Uuid) -> Result<Option<ProfileKey>, Self::Error>;
+    fn profile_key(&self, uuid: &Uuid) -> Result<Option<ProfileKey>, Self::ContentsStoreError>;
 
     /// Save a profile by [Uuid] and [ProfileKey].
     fn save_profile(
@@ -135,10 +177,33 @@ pub trait Store: ProtocolStore + SenderKeyStore + SessionStoreExt + Sync + Clone
         uuid: Uuid,
         key: ProfileKey,
         profile: Profile,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<(), Self::ContentsStoreError>;
 
     /// Retrieve a profile by [Uuid] and [ProfileKey].
-    fn profile(&self, uuid: Uuid, key: ProfileKey) -> Result<Option<Profile>, Self::Error>;
+    fn profile(
+        &self,
+        uuid: Uuid,
+        key: ProfileKey,
+    ) -> Result<Option<Profile>, Self::ContentsStoreError>;
+}
+
+/// The manager store trait combining all other stores into a single one
+pub trait Store:
+    StateStore<StateStoreError = Self::Error>
+    + PrekeysStore<PrekeysStoreError = Self::Error>
+    + ContentsStore<ContentsStoreError = Self::Error>
+    + ProtocolStore
+    + SenderKeyStore
+    + SessionStoreExt
+    + Sync
+    + Clone
+{
+    type Error: StoreError;
+
+    /// Clear the entire store
+    ///
+    /// This can be useful when resetting an existing client.
+    fn clear(&mut self) -> Result<(), <Self as StateStore>::StateStoreError>;
 }
 
 /// A thread specifies where a message was sent, either to or from a contact or in a group.
@@ -147,7 +212,7 @@ pub enum Thread {
     /// The message was sent inside a contact-chat.
     Contact(Uuid),
     // Cannot use GroupMasterKey as unable to extract the bytes.
-    /// The message was sent inside a groups-chat with the [GroupMasterKey](crate::prelude::GroupMasterKey) (specified as bytes).
+    /// The message was sent inside a groups-chat with the [`GroupMasterKeyBytes`] (specified as bytes).
     Group(GroupMasterKeyBytes),
 }
 
@@ -246,11 +311,12 @@ impl TryFrom<&Content> for Thread {
     }
 }
 
-pub trait ContentTimestamp {
+/// Extension trait of [`Content`]
+pub trait ContentExt {
     fn timestamp(&self) -> u64;
 }
 
-impl ContentTimestamp for Content {
+impl ContentExt for Content {
     /// The original timestamp of the message.
     fn timestamp(&self) -> u64 {
         match self.body {


### PR DESCRIPTION
There are several goals of this refactoring:

1. Importing of types should be obvious and unique. We try not to
   re-export types (with the exception of the `Manager` and `protos`).
2. The Store trait is split and is not an overarching trait anymore.
   Instead it is combined from several smaller traits, each responsible
   for a non-overlapping feature.
3. All public modules and types are documented (in presage).
4. `Manager` file is split in a file per type state.

Since public exports are removed and reordered, this is a breaking 
change.

TODO: 

- [x] Mark all methods from Manager that are just redirecting to the underlying Store as deprecated for later removal.
- [x] Make all fields of Registered private. Instead expose the relevant data only via getters.
- [x] Remove Serialize/Deserialize from Registered. This would hide the data inside.