### PR TITLE
fix: trust new identities

### DIFF
--- a/presage-cli/src/main.rs
+++ b/presage-cli/src/main.rs
@@ -33,6 +33,7 @@ use presage::{
     Manager,
 };
 use presage_store_sled::MigrationConflictStrategy;
+use presage_store_sled::OnNewIdentity;
 use presage_store_sled::SledStore;
 use tempfile::Builder;
 use tokio::task;
@@ -203,6 +204,7 @@ async fn main() -> anyhow::Result<()> {
         db_path,
         args.passphrase,
         MigrationConflictStrategy::Raise,
+        OnNewIdentity::Trust,
     )?;
     run(args.subcommand, config_store).await
 }

--- a/presage-store-sled/src/lib.rs
+++ b/presage-store-sled/src/lib.rs
@@ -997,17 +997,15 @@ impl IdentityKeyStore for SledStore {
                 e.into_signal_error()
             })?;
 
-        if let Ok(uuid) = address.name().parse() {
-            self.save_trusted_identity_message(
-                uuid,
-                *identity_key,
-                if existed_before {
-                    verified::State::Unverified
-                } else {
-                    verified::State::Default
-                },
-            );
-        };
+        self.save_trusted_identity_message(
+            address,
+            *identity_key,
+            if existed_before {
+                verified::State::Unverified
+            } else {
+                verified::State::Default
+            },
+        );
 
         Ok(true)
     }
@@ -1310,7 +1308,7 @@ mod tests {
 
     #[quickcheck_async::tokio]
     async fn test_store_messages(thread: Thread, content: Content) -> anyhow::Result<()> {
-        let mut db = SledStore::temporary()?;
+        let db = SledStore::temporary()?;
         let thread = thread.0;
         db.save_message(&thread, content_with_timestamp(&content, 1678295210))?;
         db.save_message(&thread, content_with_timestamp(&content, 1678295220))?;

--- a/presage/src/manager/linking.rs
+++ b/presage/src/manager/linking.rs
@@ -28,12 +28,12 @@ impl<S: Store> Manager<S, Linking> {
     /// use futures::{channel::oneshot, future, StreamExt};
     /// use presage::libsignal_service::configuration::SignalServers;
     /// use presage::Manager;
-    /// use presage_store_sled::{MigrationConflictStrategy, SledStore};
+    /// use presage_store_sled::{MigrationConflictStrategy, OnNewIdentity, SledStore};
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let store =
-    ///         SledStore::open("/tmp/presage-example", MigrationConflictStrategy::Drop)?;
+    ///         SledStore::open("/tmp/presage-example", MigrationConflictStrategy::Drop, OnNewIdentity::Trust)?;
     ///
     ///     let (mut tx, mut rx) = oneshot::channel();
     ///     let (manager, err) = future::join(

--- a/presage/src/manager/registration.rs
+++ b/presage/src/manager/registration.rs
@@ -39,12 +39,12 @@ impl<S: Store> Manager<S, Registration> {
     /// };
     /// use presage::manager::RegistrationOptions;
     /// use presage::Manager;
-    /// use presage_store_sled::{MigrationConflictStrategy, SledStore};
+    /// use presage_store_sled::{MigrationConflictStrategy, OnNewIdentity, SledStore};
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let store =
-    ///         SledStore::open("/tmp/presage-example", MigrationConflictStrategy::Drop)?;
+    ///         SledStore::open("/tmp/presage-example", MigrationConflictStrategy::Drop, OnNewIdentity::Trust)?;
     ///
     ///     let manager = Manager::register(
     ///         store,

--- a/presage/src/store.rs
+++ b/presage/src/store.rs
@@ -1,21 +1,22 @@
 //! Traits that are used by the manager for storing the data.
 
-use std::{fmt, ops::RangeBounds};
+use std::{fmt, ops::RangeBounds, time::SystemTime};
 
 use libsignal_service::{
-    content::ContentBody,
+    content::{ContentBody, Metadata},
     groups_v2::Group,
     models::Contact,
     prelude::{Content, ProfileKey, Uuid, UuidError},
     proto::{
         sync_message::{self, Sent},
-        DataMessage, EditMessage, GroupContextV2, SyncMessage,
+        verified, DataMessage, EditMessage, GroupContextV2, SyncMessage, Verified,
     },
-    protocol::{ProtocolStore, SenderKeyStore},
+    protocol::{IdentityKey, ProtocolStore, SenderKeyStore},
     session_store::SessionStoreExt,
     zkgroup::GroupMasterKeyBytes,
     Profile,
 };
+use log::error;
 use serde::{Deserialize, Serialize};
 
 use crate::manager::RegistrationData;
@@ -87,10 +88,47 @@ pub trait ContentsStore {
 
     /// Save a message in a [Thread] identified by a timestamp.
     fn save_message(
-        &mut self,
+        &self,
         thread: &Thread,
         message: Content,
     ) -> Result<(), Self::ContentsStoreError>;
+
+    /// Saves a message to mark an identity as trusted or not
+    fn save_trusted_identity_message(
+        &self,
+        contact: Uuid,
+        right_identity_key: IdentityKey,
+        verified_state: verified::State,
+    ) {
+        // TODO: this is a hack to save a message showing that the verification status changed
+        // It is possibly ok to do it like this, but rebuidling the metadata and content body feels dirty
+        let thread = Thread::Contact(contact);
+        let verified_sync_message = Content {
+            metadata: Metadata {
+                sender: contact.into(),
+                sender_device: 0,
+                timestamp: SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+                needs_receipt: false,
+                unidentified_sender: false,
+            },
+            body: SyncMessage {
+                verified: Some(Verified {
+                    destination_aci: Some(contact.to_string()),
+                    identity_key: Some(right_identity_key.public_key().serialize().to_vec()),
+                    state: Some(verified_state.into()),
+                    null_message: None,
+                }),
+                ..Default::default()
+            }
+            .into(),
+        };
+        if let Err(error) = self.save_message(&thread, verified_sync_message) {
+            error!("failed to save the verified session message in thread: {error}");
+        }
+    }
 
     /// Delete a single message, identified by its received timestamp from a thread.
     /// Useful when you want to delete a message locally only.


### PR DESCRIPTION
I never realized this was wrong, and I guess I kept re-linking as part of my tests, but there was no way for `presage` since a _very long_ time (maybe even forever) to receive messages from a contact that changed their identity (which happens when you change your phone, for example).

This PR fixes this and follows the default behavior of official Signal clients.

A `SyncMessage` is inserted in the 1-1 thread with the contact whose identity changed, which a client can interpret to display the "Your safety number with [CONTACT] has changed".

Currently, the values are used in the following way:

- `verified::State::Default` will always be saved in the timeline when the new identity is saved
- `verified::State::Unverified` will be save in the timeline when the safety number changed, letting developers display a warning to users.

Note: there is currently no way to manually mark some identity as verified in the timeline, but one could do it manually in a client.