### PR TITLE
Send profile key with messages

### DIFF
--- a/presage-cli/src/main.rs
+++ b/presage-cli/src/main.rs
@@ -2,7 +2,6 @@ use core::fmt;
 use std::convert::TryInto;
 use std::path::Path;
 use std::path::PathBuf;
-use std::time::Duration;
 use std::time::UNIX_EPOCH;
 
 use anyhow::{anyhow, bail, Context as _};
@@ -37,7 +36,6 @@ use presage_store_sled::OnNewIdentity;
 use presage_store_sled::SledStore;
 use tempfile::Builder;
 use tokio::task;
-use tokio::time::sleep;
 use tokio::{
     fs,
     io::{self, AsyncBufReadExt, BufReader},
@@ -236,14 +234,10 @@ async fn send<S: Store + 'static>(
                 }
             });
 
-            sleep(Duration::from_secs(5)).await;
-
             manager
                 .send_message(*uuid, message, timestamp)
                 .await
                 .unwrap();
-
-            sleep(Duration::from_secs(5)).await;
         })
         .await;
 

--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Gabriel Féron <g@leirbag.net>"]
 edition = "2021"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "f40eb4f" }
-libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "f40eb4f" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "afb5114" }
+libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "afb5114" }
 
 base64 = "0.21"
 futures = "0.3"


### PR DESCRIPTION
Also:

- Save profile keys from incoming message also from `SyncMessage`
- Remove quirks feature flag from `presage-cli`
- Remove sleep when sending messages with CLI now that the websockets are handled properly

Relates to #200