### PR TITLE
Enforce selecting a mode when receiving messages

### DIFF
--- a/presage-cli/src/main.rs
+++ b/presage-cli/src/main.rs
@@ -22,6 +22,7 @@ use presage::libsignal_service::proto::data_message::Quote;
 use presage::libsignal_service::proto::sync_message::Sent;
 use presage::libsignal_service::zkgroup::GroupMasterKeyBytes;
 use presage::libsignal_service::{groups_v2::Group, prelude::ProfileKey};
+use presage::manager::ReceivingMode;
 use presage::proto::EditMessage;
 use presage::proto::SyncMessage;
 use presage::store::ContentExt;
@@ -449,7 +450,7 @@ async fn receive<S: Store>(
     );
 
     let messages = manager
-        .receive_messages()
+        .receive_messages(ReceivingMode::Forever)
         .await
         .context("failed to initialize messages stream")?;
     pin_mut!(messages);

--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -331,7 +331,7 @@ impl<S: Store> Manager<S, Registered> {
         debug!("synchronizing contacts");
 
         let mut messages = pin!(
-            self.receive_messages_with_mode(ReceivingMode::WaitForContacts)
+            self.receive_messages(ReceivingMode::WaitForContacts)
                 .await?
         );
 
@@ -470,14 +470,12 @@ impl<S: Store> Manager<S, Registered> {
 
     /// Starts receiving and storing messages.
     ///
+    /// As a client, it is heavily recommended to run this once in `ReceivingMode::InitialSync` once
+    /// before enabling the possiblity of sending messages. That way, all possible updates (sessions, profile keys, sender keys)
+    /// are processed _before_ trying to encrypt and send messages which might fail otherwise.
+    ///
     /// Returns a [futures::Stream] of messages to consume. Messages will also be stored by the implementation of the [Store].
     pub async fn receive_messages(
-        &mut self,
-    ) -> Result<impl Stream<Item = Content>, Error<S::Error>> {
-        self.receive_messages_stream(ReceivingMode::Forever).await
-    }
-
-    pub async fn receive_messages_with_mode(
         &mut self,
         mode: ReceivingMode,
     ) -> Result<impl Stream<Item = Content>, Error<S::Error>> {


### PR DESCRIPTION
It is actually required to wait for all messages to sync on startup (like Signal-Desktop does) _before_ letting users send messages.

The feature was there, but this change is a minor breakage of the API to make sure clients handle this correctly.