### PR TITLE
Fix outgoing messages stored in wrong thread

### DIFF
--- a/presage/src/store.rs
+++ b/presage/src/store.rs
@@ -115,7 +115,7 @@ pub trait ContentsStore {
                 timestamp: SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .unwrap_or_default()
-                    .as_secs(),
+                    .as_millis() as u64,
                 needs_receipt: false,
                 unidentified_sender: false,
             },


### PR DESCRIPTION
Outgoing messages in 1-to-1 chats were stored in the note-to-self chat. This was broken in 6125534. This will be fixed by this MR.

This also fixes the timestamp of identity verification messages, which are inserted into the store by presage. By convention, all timestamps used are in milliseconds, this one was in seconds. This was wrong since #206.