### PR TITLE
Reconnect websockets lazily on usage

### DIFF
--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Gabriel Féron <g@leirbag.net>"]
 edition = "2021"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "9af1f42" }
-libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "9af1f42" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "0a7987e" }
+libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "0a7987e" }
 
 base64 = "0.21"
 futures = "0.3"


### PR DESCRIPTION
When identified or unidentified websocket is used, it is checked whether it is closed, and in that case it is reconnected. This is less powerful to auto-reconnecting websockets, because the messages stream would not be interrupted. But this is a very simple implementation which works quite well on application level.