### PR TITLE
Drop kyber pre keys on relinking

### DIFF
--- a/presage-store-sled/src/lib.rs
+++ b/presage-store-sled/src/lib.rs
@@ -407,6 +407,7 @@ impl StateStore for SledStore {
         db.drop_tree(SLED_TREE_SENDER_KEYS)?;
         db.drop_tree(SLED_TREE_SESSIONS)?;
         db.drop_tree(SLED_TREE_SIGNED_PRE_KEYS)?;
+        db.drop_tree(SLED_TREE_KYBER_PRE_KEYS)?;
         db.drop_tree(SLED_TREE_STATE)?;
         db.drop_tree(SLED_TREE_PROFILES)?;
         db.drop_tree(SLED_TREE_PROFILE_KEYS)?;


### PR DESCRIPTION
This caused issues for me with out-of-sync kyber and normal pre keys.