### PR TITLE
Fix reuse of websocket

### DIFF
--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Gabriel Féron <g@leirbag.net>"]
 edition = "2021"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "0a7987e" }
-libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "0a7987e" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "9d55addebe010f0acbcabdfc02ab41979c1863e0" }
+libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "9d55addebe010f0acbcabdfc02ab41979c1863e0" }
 
 base64 = "0.21"
 futures = "0.3"


### PR DESCRIPTION
When `receive_messages` is called multiple times on the same manager, this could lead to a panic "web socket request handler not in use". This fixes this.

Requires <https://github.com/whisperfish/libsignal-service-rs/pull/274>. Also currently dependent on my fork of lss.