### PR TITLE
Potential fix for expire timer turning off

### DIFF
--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -1132,7 +1132,9 @@ async fn save_message<S: Store>(
                 store.upsert_profile_key(&sender_uuid, profile_key)?;
             }
 
-            store.update_expire_timer(&thread, data_message.expire_timer.unwrap_or_default())?;
+            if let Some(expire_timer) = data_message.expire_timer {
+                store.update_expire_timer(&thread, expire_timer)?;
+            }
 
             match data_message {
                 DataMessage {


### PR DESCRIPTION
I had the assumption that once an expire timer was set, the field would always be populated. I think now that this assumption is wrong. Therefore, one should only update the expire timer if the field is really set.