### PR TITLE
fix: don't run migration conflict strategy when opening the sled store more than once

### DIFF
--- a/presage-store-sled/src/lib.rs
+++ b/presage-store-sled/src/lib.rs
@@ -355,7 +355,7 @@ fn migrate(
         Ok(())
     };
 
-    if let Err(error) = run_migrations() {
+    if let Err(SledStoreError::MigrationConflict) = run_migrations() {
         match migration_conflict_strategy {
             MigrationConflictStrategy::BackupAndDrop => {
                 let mut new_db_path = db_path.to_path_buf();
@@ -373,7 +373,7 @@ fn migrate(
             MigrationConflictStrategy::Drop => {
                 fs_extra::dir::remove(db_path)?;
             }
-            MigrationConflictStrategy::Raise => return Err(error),
+            MigrationConflictStrategy::Raise => return Err(SledStoreError::MigrationConflict),
         }
     }
 


### PR DESCRIPTION
Bubble up any error when running migrations that's not `MigrationConflict`. We should only apply the migration strategy if we have any unrecoverable error (and leave the choice of what to do to the user).

Fixes https://github.com/boxdot/gurk-rs/issues/261