### PR TITLE
Fix github pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
+      - name: Install protobuf
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libprotobuf-dev libprotobuf-c-dev protobuf-compiler protobuf-c-compiler
       - uses: actions-rs/cargo@v1
         with:
           command: doc


### PR DESCRIPTION
Totally untested change that should fix CI failing on pages build introduced in #230.

Btw, this is also broken in libsignal-service-rs.