### PR TITLE
Clarify license in Cargo.toml

### DIFF
--- a/presage-cli/Cargo.toml
+++ b/presage-cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "presage-cli"
 version = "0.6.0-dev"
 edition = "2021"
 authors = ["Gabriel Féron <g@leirbag.net>"]
+license = "AGPL-3.0-only"
 
 [dependencies]
 presage = { path = "../presage" }

--- a/presage-store-cipher/Cargo.toml
+++ b/presage-store-cipher/Cargo.toml
@@ -2,6 +2,7 @@
 name = "presage-store-cipher"
 version = "0.1.0"
 edition = "2021"
+license = "AGPL-3.0-only"
 
 [dependencies]
 blake3 = "1.5.0"

--- a/presage-store-sled/Cargo.toml
+++ b/presage-store-sled/Cargo.toml
@@ -3,6 +3,7 @@ name = "presage-store-sled"
 version = "0.6.0-dev"
 edition = "2021"
 authors = ["Gabriel Féron <g@leirbag.net>"]
+license = "AGPL-3.0-only"
 
 [build-dependencies]
 prost-build = "> 0.10, <= 0.12"

--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -4,6 +4,7 @@ name = "presage"
 version = "0.6.0-dev"
 authors = ["Gabriel Féron <g@leirbag.net>"]
 edition = "2021"
+license = "AGPL-3.0-only"
 
 [dependencies]
 libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "a2e7540a71866a62028ad0205574a5feb0e717ec" }


### PR DESCRIPTION
Was setting up `cargo-deny` for Flare and noticed presage does not have machine-readable license qualifiers in its `Cargo.toml`s. We are forced to use `AGPL-3.0-only` either way due to libsignal-service-rs and upstream.