### PR TITLE
Update libsignal-service-rs

### DIFF
--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 license = "AGPL-3.0-only"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "689a4c2" }
-libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "689a4c2" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "c072491aa3e2b604b45b9f2b764552b7d382898c" }
+libsignal-service-hyper = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "c072491aa3e2b604b45b9f2b764552b7d382898c" }
 
 base64 = "0.21"
 futures = "0.3"


### PR DESCRIPTION
Includes a fix for groups not working for a newly linked device.

See <https://github.com/whisperfish/libsignal-service-rs/issues/296> and <https://github.com/whisperfish/libsignal-service-rs/pull/297>.