### PR TITLE
fix: ignore sometimes failing migration v4 -> v5

### DIFF
--- a/presage-cli/src/main.rs
+++ b/presage-cli/src/main.rs
@@ -46,14 +46,13 @@ use url::Url;
 #[derive(Parser)]
 #[clap(about = "a basic signal CLI to try things out")]
 struct Args {
-    #[clap(long = "db-path", short = 'd', group = "store")]
+    #[clap(long = "db-path", short = 'd')]
     db_path: Option<PathBuf>,
 
     #[clap(
         help = "passphrase to encrypt the local storage",
         long = "passphrase",
-        short = 'p',
-        group = "store"
+        short = 'p'
     )]
     passphrase: Option<String>,
 


### PR DESCRIPTION
Without this we are stuck on v4, and always run the migration step. The migration sometimes fails because the there is no properly serialized data.

Also allow to specify the database path and secret at the same time.