### PR TITLE
Fix wrong expiration comparison for sender certificates

### DIFF
--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -398,7 +398,7 @@ impl<S: Store> Manager<S, Registered> {
                 .as_secs();
 
             if let Some(expiration) = sender_certificate.and_then(|s| s.expiration().ok()) {
-                seconds_since_epoch <= expiration.epoch_millis() / 1000 + 600
+                expiration.epoch_millis() / 1000 <= seconds_since_epoch + 600
             } else {
                 true
             }


### PR DESCRIPTION
This was modified in f93f2dee5b9f0ca3b30b545143194431d9136549 and the bug slipped in.