### PR TITLE
Adjust code to latest libsignal-service-rs

### DIFF
--- a/presage-cli/src/main.rs
+++ b/presage-cli/src/main.rs
@@ -17,13 +17,14 @@ use presage::libsignal_service::content::Reaction;
 use presage::libsignal_service::models::Contact;
 use presage::libsignal_service::pre_keys::PreKeysStore;
 use presage::libsignal_service::prelude::phonenumber::PhoneNumber;
+use presage::libsignal_service::prelude::ProfileKey;
 use presage::libsignal_service::prelude::Uuid;
 use presage::libsignal_service::proto::data_message::Quote;
 use presage::libsignal_service::proto::sync_message::Sent;
 use presage::libsignal_service::zkgroup::GroupMasterKeyBytes;
 use presage::libsignal_service::ServiceAddress;
-use presage::libsignal_service::{groups_v2::Group, prelude::ProfileKey};
 use presage::manager::ReceivingMode;
+use presage::model::groups::Group;
 use presage::proto::receipt_message;
 use presage::proto::EditMessage;
 use presage::proto::ReceiptMessage;
@@ -256,7 +257,7 @@ async fn send<S: Store>(
                 Recipient::Contact(uuid) => {
                     info!(recipient =% uuid, "sending message to contact");
                     manager
-                        .send_message(ServiceAddress::new_aci(uuid), content_body, timestamp)
+                        .send_message(ServiceAddress::from_aci(uuid), content_body, timestamp)
                         .await
                         .expect("failed to send message");
                 }

--- a/presage-store-sled/src/content.rs
+++ b/presage-store-sled/src/content.rs
@@ -6,12 +6,12 @@ use std::{
 use presage::{
     libsignal_service::{
         content::Content,
-        groups_v2::Group,
         models::Contact,
         prelude::Uuid,
         zkgroup::{profiles::ProfileKey, GroupMasterKeyBytes},
         Profile,
     },
+    model::groups::Group,
     store::{ContentExt, ContentsStore, StickerPack, Thread},
     AvatarBytes,
 };
@@ -116,9 +116,9 @@ impl ContentsStore for SledStore {
     fn save_group(
         &self,
         master_key: GroupMasterKeyBytes,
-        group: &Group,
+        group: impl Into<Group>,
     ) -> Result<(), SledStoreError> {
-        self.insert(SLED_TREE_GROUPS, master_key, group)?;
+        self.insert(SLED_TREE_GROUPS, master_key, group.into())?;
         Ok(())
     }
 

--- a/presage-store-sled/src/protobuf.rs
+++ b/presage-store-sled/src/protobuf.rs
@@ -34,7 +34,7 @@ impl TryFrom<AddressProto> for ServiceAddress {
             .uuid
             .and_then(|bytes| Some(Uuid::from_bytes(bytes.try_into().ok()?)))
             .ok_or_else(|| SledStoreError::NoUuid)
-            .map(Self::new_aci)
+            .map(Self::from_aci)
     }
 }
 
@@ -60,7 +60,7 @@ impl TryFrom<MetadataProto> for Metadata {
     fn try_from(metadata: MetadataProto) -> Result<Self, Self::Error> {
         Ok(Metadata {
             sender: metadata.address.ok_or(SledStoreError::NoUuid)?.try_into()?,
-            destination: ServiceAddress::new_aci(match metadata.destination_uuid.as_deref() {
+            destination: ServiceAddress::from_aci(match metadata.destination_uuid.as_deref() {
                 Some(value) => value.parse().map_err(|_| SledStoreError::NoUuid),
                 None => Ok(Uuid::nil()),
             }?),

--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "AGPL-3.0-only"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "701ee93358b3fce75e26489b530e807a76254166" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "72f89cdf6bdda1c828319e50f65d8ead2c376351" }
 
 base64 = "0.22"
 futures = "0.3"
@@ -20,6 +20,8 @@ thiserror = "1.0"
 tokio = { version = "1.35", default-features = false, features = ["sync", "time"] }
 tracing = "0.1"
 url = "2.5"
+serde_with = "3.11.0"
+derivative = "2.2.0"
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/presage/src/lib.rs
+++ b/presage/src/lib.rs
@@ -1,5 +1,6 @@
 mod errors;
 pub mod manager;
+pub mod model;
 mod serde;
 pub mod store;
 

--- a/presage/src/model/groups.rs
+++ b/presage/src/model/groups.rs
@@ -1,0 +1,84 @@
+use derivative::Derivative;
+use libsignal_service::{
+    groups_v2::Role,
+    prelude::{AccessControl, Member, ProfileKey, Timer, Uuid},
+};
+use serde::{Deserialize, Serialize};
+
+use super::ServiceIdType;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Group {
+    pub title: String,
+    pub avatar: String,
+    pub disappearing_messages_timer: Option<Timer>,
+    pub access_control: Option<AccessControl>,
+    pub revision: u32,
+    pub members: Vec<Member>,
+    pub pending_members: Vec<PendingMember>,
+    pub requesting_members: Vec<RequestingMember>,
+    pub invite_link_password: Vec<u8>,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct PendingMember {
+    // for backwards compatibility
+    pub uuid: Uuid,
+    #[serde(default)]
+    pub service_id_type: ServiceIdType,
+    pub role: Role,
+    pub added_by_uuid: Uuid,
+    pub timestamp: u64,
+}
+
+#[derive(Derivative, Clone, Deserialize, Serialize)]
+#[derivative(Debug)]
+pub struct RequestingMember {
+    pub uuid: Uuid,
+    pub profile_key: ProfileKey,
+    pub timestamp: u64,
+}
+
+impl Into<Group> for libsignal_service::groups_v2::Group {
+    fn into(self) -> Group {
+        Group {
+            title: self.title,
+            avatar: self.avatar,
+            disappearing_messages_timer: self.disappearing_messages_timer,
+            access_control: self.access_control,
+            revision: self.revision,
+            members: self.members,
+            pending_members: self.pending_members.into_iter().map(Into::into).collect(),
+            requesting_members: self
+                .requesting_members
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            invite_link_password: self.invite_link_password,
+            description: self.description,
+        }
+    }
+}
+
+impl Into<PendingMember> for libsignal_service::groups_v2::PendingMember {
+    fn into(self) -> PendingMember {
+        PendingMember {
+            uuid: self.address.uuid,
+            service_id_type: self.address.identity.into(),
+            role: self.role,
+            added_by_uuid: self.added_by_uuid,
+            timestamp: self.timestamp,
+        }
+    }
+}
+
+impl Into<RequestingMember> for libsignal_service::groups_v2::RequestingMember {
+    fn into(self) -> RequestingMember {
+        RequestingMember {
+            uuid: self.uuid,
+            profile_key: self.profile_key,
+            timestamp: self.timestamp,
+        }
+    }
+}

--- a/presage/src/model/mod.rs
+++ b/presage/src/model/mod.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+
+pub mod groups;
+
+#[derive(Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub enum ServiceIdType {
+    /// Account Identity (ACI)
+    ///
+    /// An account UUID without an associated phone number, probably in the future to a username
+    #[default]
+    AccountIdentity,
+    /// Phone number identity (PNI)
+    ///
+    /// A UUID associated with a phone number
+    PhoneNumberIdentity,
+}
+
+impl Into<ServiceIdType> for libsignal_service::ServiceIdType {
+    fn into(self) -> ServiceIdType {
+        match self {
+            libsignal_service::ServiceIdType::AccountIdentity => ServiceIdType::AccountIdentity,
+            libsignal_service::ServiceIdType::PhoneNumberIdentity => {
+                ServiceIdType::PhoneNumberIdentity
+            }
+        }
+    }
+}

--- a/presage/src/store.rs
+++ b/presage/src/store.rs
@@ -4,7 +4,7 @@ use std::{fmt, ops::RangeBounds, time::SystemTime};
 
 use libsignal_service::{
     content::{ContentBody, Metadata},
-    groups_v2::{Group, Timer},
+    groups_v2::Timer,
     models::Contact,
     pre_keys::PreKeysStore,
     prelude::{Content, ProfileKey, Uuid, UuidError},
@@ -20,7 +20,7 @@ use libsignal_service::{
 use serde::{Deserialize, Serialize};
 use tracing::{error, trace};
 
-use crate::{manager::RegistrationData, AvatarBytes};
+use crate::{manager::RegistrationData, model::groups::Group, AvatarBytes};
 
 /// An error trait implemented by store error types
 pub trait StoreError: std::error::Error + Sync + Send {}
@@ -111,8 +111,8 @@ pub trait ContentsStore: Send + Sync {
         let thread = Thread::Contact(sender);
         let verified_sync_message = Content {
             metadata: Metadata {
-                sender: ServiceAddress::new_aci(sender),
-                destination: ServiceAddress::new_aci(sender),
+                sender: ServiceAddress::from_aci(sender),
+                destination: ServiceAddress::from_aci(sender),
                 sender_device: 0,
                 server_guid: None,
                 timestamp: SystemTime::now()
@@ -206,7 +206,7 @@ pub trait ContentsStore: Send + Sync {
                 let group = self.group(*key)?;
                 if let Some(mut g) = group {
                     g.disappearing_messages_timer = Some(Timer { duration: timer });
-                    self.save_group(*key, &g)?;
+                    self.save_group(*key, g)?;
                 }
                 Ok(())
             }
@@ -234,7 +234,7 @@ pub trait ContentsStore: Send + Sync {
     fn save_group(
         &self,
         master_key: GroupMasterKeyBytes,
-        group: &Group,
+        group: impl Into<Group>,
     ) -> Result<(), Self::ContentsStoreError>;
 
     /// Get an iterator on all cached groups


### PR DESCRIPTION
Introduce the first few mirror structs to avoid store breakage when things change on the lss side.