### PR TITLE
[breaking] Switch Store traits to async Rust

### DIFF
--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # be a sign or warning of (an imminent event, typically an unwelcome one).
 name = "presage"
-version = "0.6.2"
+version = "0.7.0-dev"
 authors = ["Gabriel Féron <g@leirbag.net>"]
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/presage/src/manager/linking.rs
+++ b/presage/src/manager/linking.rs
@@ -34,7 +34,7 @@ impl<S: Store> Manager<S, Linking> {
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let store =
-    ///         SledStore::open("/tmp/presage-example", MigrationConflictStrategy::Drop, OnNewIdentity::Trust)?;
+    ///         SledStore::open("/tmp/presage-example", MigrationConflictStrategy::Drop, OnNewIdentity::Trust).await?;
     ///
     ///     let (mut tx, mut rx) = oneshot::channel();
     ///     let (manager, err) = future::join(

--- a/presage/src/manager/registration.rs
+++ b/presage/src/manager/registration.rs
@@ -73,19 +73,18 @@ impl<S: Store> Manager<S, Registration> {
         } = registration_options;
 
         // check if we are already registered
-        if !force && store.is_registered() {
+        if !force && store.is_registered().await {
             return Err(Error::AlreadyRegisteredError);
         }
 
-        store.clear_registration()?;
+        store.clear_registration().await?;
 
         // generate a random alphanumeric 24 chars password
         let mut rng = StdRng::from_entropy();
         let password = Alphanumeric.sample_string(&mut rng, 24);
 
         let service_configuration: ServiceConfiguration = signal_servers.into();
-        let mut push_service =
-            PushService::new(service_configuration, None, crate::USER_AGENT.to_string());
+        let mut push_service = PushService::new(service_configuration, None, crate::USER_AGENT);
 
         trace!("creating registration verification session");
 

--- a/presage/src/manager/registration.rs
+++ b/presage/src/manager/registration.rs
@@ -43,7 +43,7 @@ impl<S: Store> Manager<S, Registration> {
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let store =
-    ///         SledStore::open("/tmp/presage-example", MigrationConflictStrategy::Drop, OnNewIdentity::Trust)?;
+    ///         SledStore::open("/tmp/presage-example", MigrationConflictStrategy::Drop, OnNewIdentity::Trust).await?;
     ///
     ///     let manager = Manager::register(
     ///         store,

--- a/presage/src/model/groups.rs
+++ b/presage/src/model/groups.rs
@@ -50,11 +50,7 @@ impl From<libsignal_service::groups_v2::Group> for Group {
             revision: val.revision,
             members: val.members,
             pending_members: val.pending_members.into_iter().map(Into::into).collect(),
-            requesting_members: val
-                .requesting_members
-                .into_iter()
-                .map(Into::into)
-                .collect(),
+            requesting_members: val.requesting_members.into_iter().map(Into::into).collect(),
             invite_link_password: val.invite_link_password,
             description: val.description,
         }

--- a/presage/src/model/groups.rs
+++ b/presage/src/model/groups.rs
@@ -40,45 +40,45 @@ pub struct RequestingMember {
     pub timestamp: u64,
 }
 
-impl Into<Group> for libsignal_service::groups_v2::Group {
-    fn into(self) -> Group {
+impl From<libsignal_service::groups_v2::Group> for Group {
+    fn from(val: libsignal_service::groups_v2::Group) -> Self {
         Group {
-            title: self.title,
-            avatar: self.avatar,
-            disappearing_messages_timer: self.disappearing_messages_timer,
-            access_control: self.access_control,
-            revision: self.revision,
-            members: self.members,
-            pending_members: self.pending_members.into_iter().map(Into::into).collect(),
-            requesting_members: self
+            title: val.title,
+            avatar: val.avatar,
+            disappearing_messages_timer: val.disappearing_messages_timer,
+            access_control: val.access_control,
+            revision: val.revision,
+            members: val.members,
+            pending_members: val.pending_members.into_iter().map(Into::into).collect(),
+            requesting_members: val
                 .requesting_members
                 .into_iter()
                 .map(Into::into)
                 .collect(),
-            invite_link_password: self.invite_link_password,
-            description: self.description,
+            invite_link_password: val.invite_link_password,
+            description: val.description,
         }
     }
 }
 
-impl Into<PendingMember> for libsignal_service::groups_v2::PendingMember {
-    fn into(self) -> PendingMember {
+impl From<libsignal_service::groups_v2::PendingMember> for PendingMember {
+    fn from(val: libsignal_service::groups_v2::PendingMember) -> Self {
         PendingMember {
-            uuid: self.address.uuid,
-            service_id_type: self.address.identity.into(),
-            role: self.role,
-            added_by_uuid: self.added_by_uuid,
-            timestamp: self.timestamp,
+            uuid: val.address.uuid,
+            service_id_type: val.address.identity.into(),
+            role: val.role,
+            added_by_uuid: val.added_by_uuid,
+            timestamp: val.timestamp,
         }
     }
 }
 
-impl Into<RequestingMember> for libsignal_service::groups_v2::RequestingMember {
-    fn into(self) -> RequestingMember {
+impl From<libsignal_service::groups_v2::RequestingMember> for RequestingMember {
+    fn from(val: libsignal_service::groups_v2::RequestingMember) -> Self {
         RequestingMember {
-            uuid: self.uuid,
-            profile_key: self.profile_key,
-            timestamp: self.timestamp,
+            uuid: val.uuid,
+            profile_key: val.profile_key,
+            timestamp: val.timestamp,
         }
     }
 }

--- a/presage/src/model/mod.rs
+++ b/presage/src/model/mod.rs
@@ -16,9 +16,9 @@ pub enum ServiceIdType {
     PhoneNumberIdentity,
 }
 
-impl Into<ServiceIdType> for libsignal_service::ServiceIdType {
-    fn into(self) -> ServiceIdType {
-        match self {
+impl From<libsignal_service::ServiceIdType> for ServiceIdType {
+    fn from(val: libsignal_service::ServiceIdType) -> Self {
+        match val {
             libsignal_service::ServiceIdType::AccountIdentity => ServiceIdType::AccountIdentity,
             libsignal_service::ServiceIdType::PhoneNumberIdentity => {
                 ServiceIdType::PhoneNumberIdentity


### PR DESCRIPTION
Since everything else was already `async` it shouldn't be a massively breaking change. This is in preparation of adding other implementations of the store traits, namely `sqlx` with `sqlite`.