### PR TITLE
Set timestamp for every DataMessage

### DIFF
--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -870,6 +870,7 @@ impl<S: Store> Manager<S, Registered> {
                 .profile_key
                 .get_or_insert(self.state.data.profile_key().get_bytes().to_vec());
             message.required_protocol_version = Some(0);
+            message.timestamp = Some(timestamp);
         }
 
         sender


### PR DESCRIPTION
This imitates the behaviour of Signal-Desktop and is required to pass envelope content validation. Previous reactions would emit this field.

This is less error-prone than requiring clients to send the timestamp in data messages.

Fixes some more instances of https://github.com/boxdot/gurk-rs/issues/110 and https://github.com/boxdot/gurk-rs/issues/147.