### PR TITLE
Bump libsignal-service with adjustments

### DIFF
--- a/presage-store-sled/src/lib.rs
+++ b/presage-store-sled/src/lib.rs
@@ -540,8 +540,7 @@ mod tests {
         content::{ContentBody, Metadata},
         prelude::Uuid,
         proto::DataMessage,
-        protocol::PreKeyId,
-        ServiceAddress, ServiceIdType,
+        protocol::{PreKeyId, ServiceId},
     };
     use presage::store::ContentsStore;
     use protocol::SledPreKeyId;
@@ -581,15 +580,11 @@ mod tests {
                 Uuid::from_u128(Arbitrary::arbitrary(g)),
                 Uuid::from_u128(Arbitrary::arbitrary(g)),
             ];
+            let sender_uuid: Uuid = *g.choose(&contacts).unwrap();
+            let destination_uuid: Uuid = *g.choose(&contacts).unwrap();
             let metadata = Metadata {
-                sender: ServiceAddress {
-                    uuid: *g.choose(&contacts).unwrap(),
-                    identity: ServiceIdType::AccountIdentity,
-                },
-                destination: ServiceAddress {
-                    uuid: *g.choose(&contacts).unwrap(),
-                    identity: ServiceIdType::AccountIdentity,
-                },
+                sender: ServiceId::Aci(sender_uuid.into()),
+                destination: ServiceId::Aci(destination_uuid.into()),
                 sender_device: Arbitrary::arbitrary(g),
                 server_guid: None,
                 timestamp,

--- a/presage-store-sqlite/src/protocol.rs
+++ b/presage-store-sqlite/src/protocol.rs
@@ -6,11 +6,10 @@ use presage::libsignal_service::{
     protocol::{
         Direction, IdentityKey, IdentityKeyPair, KyberPreKeyId, KyberPreKeyRecord,
         KyberPreKeyStore, PreKeyId, PreKeyRecord, PreKeyStore, ProtocolAddress, ProtocolStore,
-        SenderKeyRecord, SenderKeyStore, SessionRecord, SessionStore,
+        SenderKeyRecord, SenderKeyStore, ServiceId, SessionRecord, SessionStore,
         SignalProtocolError as ProtocolError, SignedPreKeyId, SignedPreKeyRecord,
         SignedPreKeyStore,
     },
-    ServiceAddress,
 };
 
 use crate::SqliteStore;
@@ -47,10 +46,7 @@ impl SessionStoreExt for SqliteProtocolStore {
     /// Get the IDs of all known sub devices with active sessions for a recipient.
     ///
     /// This should return every device except for the main device [DEFAULT_DEVICE_ID].
-    async fn get_sub_device_sessions(
-        &self,
-        name: &ServiceAddress,
-    ) -> Result<Vec<u32>, ProtocolError> {
+    async fn get_sub_device_sessions(&self, name: &ServiceId) -> Result<Vec<u32>, ProtocolError> {
         todo!()
     }
 
@@ -63,7 +59,7 @@ impl SessionStoreExt for SqliteProtocolStore {
     /// ID.
     ///
     /// Returns the number of deleted sessions.
-    async fn delete_all_sessions(&self, address: &ServiceAddress) -> Result<usize, ProtocolError> {
+    async fn delete_all_sessions(&self, address: &ServiceId) -> Result<usize, ProtocolError> {
         todo!()
     }
 }

--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "AGPL-3.0-only"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "468fa6f84cce0db3bdf11609d165758291da99df" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "6401dc34872a5f0c2fba32c1f136d98ccf3dd418" }
 
 base64 = "0.22"
 futures = "0.3"

--- a/presage/src/manager/linking.rs
+++ b/presage/src/manager/linking.rs
@@ -158,7 +158,7 @@ impl<S: Store> Manager<S, Linking> {
                 );
 
                 let mut manager = Manager {
-                    rng,
+                    csprng: rng,
                     store: store.clone(),
                     state: Registered::with_data(registration_data),
                 };

--- a/presage/src/manager/mod.rs
+++ b/presage/src/manager/mod.rs
@@ -28,7 +28,7 @@ pub struct Manager<Store, State> {
     /// Part of the manager which is persisted in the store.
     state: State,
     /// Random number generator
-    rng: StdRng,
+    csprng: StdRng,
 }
 
 impl<Store, State: fmt::Debug> fmt::Debug for Manager<Store, State> {

--- a/presage/src/manager/registration.rs
+++ b/presage/src/manager/registration.rs
@@ -136,7 +136,7 @@ impl<S: Store> Manager<S, Registration> {
                 password,
                 session_id: session.id,
             },
-            rng,
+            csprng: rng,
         };
 
         Ok(manager)

--- a/presage/src/model/groups.rs
+++ b/presage/src/model/groups.rs
@@ -60,8 +60,8 @@ impl From<libsignal_service::groups_v2::Group> for Group {
 impl From<libsignal_service::groups_v2::PendingMember> for PendingMember {
     fn from(val: libsignal_service::groups_v2::PendingMember) -> Self {
         PendingMember {
-            uuid: val.address.uuid,
-            service_id_type: val.address.identity.into(),
+            uuid: val.address.raw_uuid(),
+            service_id_type: val.address.kind().into(),
             role: val.role,
             added_by_uuid: val.added_by_uuid,
             timestamp: val.timestamp,

--- a/presage/src/model/mod.rs
+++ b/presage/src/model/mod.rs
@@ -1,3 +1,4 @@
+use libsignal_service::protocol::ServiceIdKind;
 use serde::{Deserialize, Serialize};
 
 pub mod contacts;
@@ -17,13 +18,11 @@ pub enum ServiceIdType {
     PhoneNumberIdentity,
 }
 
-impl From<libsignal_service::ServiceIdType> for ServiceIdType {
-    fn from(val: libsignal_service::ServiceIdType) -> Self {
+impl From<ServiceIdKind> for ServiceIdType {
+    fn from(val: ServiceIdKind) -> Self {
         match val {
-            libsignal_service::ServiceIdType::AccountIdentity => ServiceIdType::AccountIdentity,
-            libsignal_service::ServiceIdType::PhoneNumberIdentity => {
-                ServiceIdType::PhoneNumberIdentity
-            }
+            ServiceIdKind::Aci => ServiceIdType::AccountIdentity,
+            ServiceIdKind::Pni => ServiceIdType::PhoneNumberIdentity,
         }
     }
 }


### PR DESCRIPTION
Update `libsignal-service-rs` to include recent fixes to make sure we use the same `Rng` everywhere. This is an attempt to fix an issue where sessions are reset by the official clients on the other side.

Issues that should be fixed once `gurk` starts using this:
- https://github.com/boxdot/gurk-rs/issues/281
- https://github.com/boxdot/gurk-rs/issues/234