### PR TITLE
fix: rng state reusage

### DIFF
--- a/presage/src/manager/linking.rs
+++ b/presage/src/manager/linking.rs
@@ -7,8 +7,7 @@ use libsignal_service::provisioning::{
     link_device, NewDeviceRegistration, SecondaryDeviceProvisioning,
 };
 use rand::distributions::{Alphanumeric, DistString};
-use rand::rngs::StdRng;
-use rand::{RngCore, SeedableRng};
+use rand::{thread_rng, RngCore};
 use tracing::info;
 use url::Url;
 
@@ -68,7 +67,7 @@ impl<S: Store> Manager<S, Linking> {
         store.clear_registration().await?;
 
         // generate a random alphanumeric 24 chars password
-        let mut rng = StdRng::from_entropy();
+        let mut rng = thread_rng();
         let password = Alphanumeric.sample_string(&mut rng, 24);
 
         // generate a 52 bytes signaling key
@@ -158,7 +157,6 @@ impl<S: Store> Manager<S, Linking> {
                 );
 
                 let mut manager = Manager {
-                    csprng: rng,
                     store: store.clone(),
                     state: Registered::with_data(registration_data),
                 };

--- a/presage/src/manager/mod.rs
+++ b/presage/src/manager/mod.rs
@@ -7,8 +7,6 @@ mod registration;
 
 use std::fmt;
 
-use rand::rngs::StdRng;
-
 pub use self::confirmation::Confirmation;
 pub use self::linking::Linking;
 pub use self::registered::{ReceivingMode, Registered, RegistrationData, RegistrationType};
@@ -27,8 +25,6 @@ pub struct Manager<Store, State> {
     store: Store,
     /// Part of the manager which is persisted in the store.
     state: State,
-    /// Random number generator
-    csprng: StdRng,
 }
 
 impl<Store, State: fmt::Debug> fmt::Debug for Manager<Store, State> {

--- a/presage/src/manager/registration.rs
+++ b/presage/src/manager/registration.rs
@@ -2,8 +2,7 @@ use libsignal_service::configuration::{ServiceConfiguration, SignalServers};
 use libsignal_service::prelude::phonenumber::PhoneNumber;
 use libsignal_service::push_service::{PushService, VerificationTransport};
 use rand::distributions::{Alphanumeric, DistString};
-use rand::rngs::StdRng;
-use rand::SeedableRng;
+use rand::thread_rng;
 use tracing::trace;
 
 use crate::store::Store;
@@ -82,7 +81,7 @@ impl<S: Store> Manager<S, Registration> {
         store.clear_registration().await?;
 
         // generate a random alphanumeric 24 chars password
-        let mut rng = StdRng::from_entropy();
+        let mut rng = thread_rng();
         let password = Alphanumeric.sample_string(&mut rng, 24);
 
         let service_configuration: ServiceConfiguration = signal_servers.into();
@@ -136,7 +135,6 @@ impl<S: Store> Manager<S, Registration> {
                 password,
                 session_id: session.id,
             },
-            csprng: rng,
         };
 
         Ok(manager)

--- a/presage/src/store.rs
+++ b/presage/src/store.rs
@@ -542,7 +542,7 @@ pub async fn save_trusted_identity_message<S: Store>(
     let thread = Thread::Contact(sender.raw_uuid());
     let verified_sync_message = Content {
         metadata: Metadata {
-            sender: sender,
+            sender,
             destination: sender,
             sender_device: 0,
             server_guid: None,


### PR DESCRIPTION
StdRng was cloned, which created a new rng with the same state. This
means that the same random numbers were generated:

```rust
use rand::{Rng, SeedableRng};
use rand::rngs::StdRng;

let mut rng1 = StdRng::from_entropy();
let mut rng2 = rng1.clone();

assert_eq!(rng1.gen::<u32>(), rng2.gen::<u32>());
```

This commit replaces the `StdRng` with `ThreadRng` in all places where it
was used. It also does not store the rng in manager anymore.

The credits for finding this bug go to @hrdl-github
<31923882+hrdl-github@users.noreply.github.com>.