### PR TITLE
Bump libsignal-service

### DIFF
--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "AGPL-3.0-only"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "268e0c47e0924597b6379e6f1b5df58abd46d5ca" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "19c0c78da7a7479954634580a5e5081e7a8f2897" }
 
 base64 = "0.22"
 futures = "0.3"


### PR DESCRIPTION
To get two important patches:
- https://github.com/whisperfish/libsignal-service-rs/pull/351 (backend refuses to establish websocket connection without this change)
- https://github.com/whisperfish/libsignal-service-rs/pull/350