### PR TITLE
chore: upgrade libsignal-service

### DIFF
--- a/presage-store-sled/src/lib.rs
+++ b/presage-store-sled/src/lib.rs
@@ -590,6 +590,7 @@ mod tests {
                 timestamp,
                 needs_receipt: Arbitrary::arbitrary(g),
                 unidentified_sender: Arbitrary::arbitrary(g),
+                was_plaintext: false,
             };
             let content_body = ContentBody::DataMessage(DataMessage {
                 body: Arbitrary::arbitrary(g),

--- a/presage-store-sled/src/protobuf.rs
+++ b/presage-store-sled/src/protobuf.rs
@@ -80,6 +80,7 @@ impl TryFrom<MetadataProto> for Metadata {
                 .unwrap_or_default(),
             needs_receipt: metadata.needs_receipt.unwrap_or_default(),
             unidentified_sender: false,
+            was_plaintext: false,
         })
     }
 }

--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "AGPL-3.0-only"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "43aa16f2c49d34b21f42733d81a5c9739d9a1ed4" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "82d70f6720e762898f34ae76b0894b0297d9b2f8" }
 
 base64 = "0.22"
 futures = "0.3"

--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -858,6 +858,7 @@ impl<S: Store> Manager<S, Registered> {
                 timestamp,
                 needs_receipt: false,
                 unidentified_sender: false,
+                was_plaintext: false,
             },
             body: content_body,
         };
@@ -964,6 +965,7 @@ impl<S: Store> Manager<S, Registered> {
                 timestamp,
                 needs_receipt: false, // TODO: this is just wrong
                 unidentified_sender: false,
+                was_plaintext: false,
             },
             body: content_body,
         };

--- a/presage/src/store.rs
+++ b/presage/src/store.rs
@@ -552,6 +552,7 @@ pub async fn save_trusted_identity_message<S: Store>(
                 .as_millis() as u64,
             needs_receipt: false,
             unidentified_sender: false,
+            was_plaintext: false,
         },
         body: SyncMessage {
             verified: Some(Verified {


### PR DESCRIPTION
Brings resolution patches for the following security advisories:
- https://github.com/whisperfish/libsignal-service-rs/security/advisories/GHSA-hrrc-wpfw-5hj2
- https://github.com/whisperfish/libsignal-service-rs/security/advisories/GHSA-r58q-66g9-h6g8