### PR TITLE
Fix attachment uploads to CDN3

### DIFF
--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "AGPL-3.0-only"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "82d70f6720e762898f34ae76b0894b0297d9b2f8" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "f94d55bf8d742699024c26ca3965e85fc9946e23" }
 
 base64 = "0.22"
 futures = "0.3"


### PR DESCRIPTION
Updates `libsignal-service-rs` to include https://github.com/whisperfish/libsignal-service-rs/pull/356 from @ccstolley.