### PR TITLE
Add tokio::rt feature flag

### DIFF
--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0"
 sha2 = "0.10.8"
 thiserror = "1.0"
 tokio = { version = "1.35", default-features = false, features = [
+    "rt",
     "sync",
     "time",
 ] }


### PR DESCRIPTION
To be able to use [block_in_place](https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html).

This is unfortunately a leaky abstraction from tokio. I would however not expect any user of this library to use anything but the default tokio rt-multi-thread runtime.

Fixes standalone compilation of `presage` and docs generation in CI.