### PR TITLE
fix(store-sqlite): locked db errors

### DIFF
--- a/presage-store-sqlite/src/protocol.rs
+++ b/presage-store-sqlite/src/protocol.rs
@@ -532,7 +532,7 @@ impl IdentityKeyStore for SqliteProtocolStore {
                 self.identity,
                 bytes,
             )
-            .execute(&self.store.db)
+            .execute(&mut *tx)
             .await
             .into_protocol_error()?;
         }


### PR DESCRIPTION
While holding a transaction, we were using another connection from the pool.