### PR TITLE
Offload large attachment decryption to another thread

### DIFF
--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -38,7 +38,7 @@ use rand::rngs::ThreadRng;
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
-use tokio::{sync::Mutex, task::block_in_place};
+use tokio::sync::Mutex;
 use tracing::{debug, error, info, trace, warn};
 use url::Url;
 
@@ -1042,7 +1042,19 @@ impl<S: Store> Manager<S, Registered> {
         }
 
         let key: [u8; 64] = attachment_pointer.key().try_into()?;
-        block_in_place(|| decrypt_in_place(key, &mut ciphertext))?;
+
+        // Offload decryption of large attachments to another thread.
+        // Chose arbitrary threshold here.
+        const DECRYPT_IN_THREAD_THRESHOLD: usize = 100 * 1024;
+        if ciphertext.len() > DECRYPT_IN_THREAD_THRESHOLD {
+            ciphertext = tokio::task::spawn_blocking(move || {
+                decrypt_in_place(key, &mut ciphertext).map(|_| ciphertext)
+            })
+            .await
+            .expect("decryption in another thread")?;
+        } else {
+            decrypt_in_place(key, &mut ciphertext)?;
+        };
 
         if let Some(len) = plaintext_len {
             if len < ciphertext.len() {


### PR DESCRIPTION
#307 wrapped `decrypt_in_place()` in `block_in_place()`, which makes it impossible to run the manager on a single-threaded executor:

```
thread '<unnamed>' panicked at /home/kaspar/.cargo/git/checkouts/presage-ce211e77a0d9397d/0da7b57/presage/src/manager/registered.rs:1045:9:
can call blocking only when running on the multi-threaded runtime
```

I guess there was an issue with larger attachments. So this PR makes tokio spawn a thread for the decryption, if the attachment size exceeds a threshold value. I arbitrarily set that threshold to 100k.