### PR TITLE
Fixes for the sqlite store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3223,6 +3223,8 @@ dependencies = [
  "smallvec",
  "sqlformat",
  "thiserror 1.0.65",
+ "tokio",
+ "tokio-stream",
  "tracing",
  "url",
  "uuid",
@@ -3263,6 +3265,7 @@ dependencies = [
  "sqlx-sqlite",
  "syn 2.0.87",
  "tempfile",
+ "tokio",
  "url",
 ]
 
@@ -3599,6 +3602,17 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/presage-store-sqlite/Cargo.toml
+++ b/presage-store-sqlite/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "1.9.0"
 chrono = "0.4.38"
 prost = "0.13.4"
 serde_json = "1.0.135"
-sqlx = { version = "0.8.2", features = ["json", "sqlite", "uuid"] }
+sqlx = { version = "0.8.2", features = ["json", "sqlite", "uuid", "runtime-tokio"] }
 thiserror = "2.0.0"
 tracing = "0.1.41"
 uuid = "1.12.0"

--- a/presage-store-sqlite/src/content.rs
+++ b/presage-store-sqlite/src/content.rs
@@ -22,14 +22,20 @@ use crate::{
 impl ContentsStore for SqliteStore {
     type ContentsStoreError = SqliteStoreError;
 
-    type ContactsIter = Box<dyn Iterator<Item = Result<Contact, Self::ContentsStoreError>>>;
+    type ContactsIter =
+        Box<dyn Iterator<Item = Result<Contact, Self::ContentsStoreError>> + Send + Sync>;
 
-    type GroupsIter =
-        Box<dyn Iterator<Item = Result<(GroupMasterKeyBytes, Group), Self::ContentsStoreError>>>;
+    type GroupsIter = Box<
+        dyn Iterator<Item = Result<(GroupMasterKeyBytes, Group), Self::ContentsStoreError>>
+            + Send
+            + Sync,
+    >;
 
-    type MessagesIter = Box<dyn Iterator<Item = Result<Content, Self::ContentsStoreError>>>;
+    type MessagesIter =
+        Box<dyn Iterator<Item = Result<Content, Self::ContentsStoreError>> + Send + Sync>;
 
-    type StickerPacksIter = Box<dyn Iterator<Item = Result<StickerPack, Self::ContentsStoreError>>>;
+    type StickerPacksIter =
+        Box<dyn Iterator<Item = Result<StickerPack, Self::ContentsStoreError>> + Send + Sync>;
 
     async fn clear_profiles(&mut self) -> Result<(), Self::ContentsStoreError> {
         todo!()


### PR DESCRIPTION
Those were required to port Flare to the sqlite store. It is just two changes:

- Make the iterators of the store `Send + Sync` (Flare has a separate thread for presage and the store, and will need to send this iterator to the UI thread).
- Add the `runtime-tokio` feature to sqlx. Otherwise sqlx crashed for me during startup. I could probably also add that feature in the Flare dependencies if you don't want to hardcode tokio in there.