### PR TITLE
Add license to sqlite store crate

### DIFF
--- a/presage-store-sqlite/Cargo.toml
+++ b/presage-store-sqlite/Cargo.toml
@@ -2,6 +2,7 @@
 name = "presage-store-sqlite"
 version = "0.1.0"
 edition = "2024"
+license = "AGPL-3.0-only"
 
 [dependencies]
 presage = { path = "../presage" }


### PR DESCRIPTION
`cargo deny` of Flare CI was complaining.

As far as I see, the license is pretty much enforced either way as the sqlite store depends on presage, which is also licensed `AGPL-3.0-only`. But I'm not a lawyer, so maybe in theory we could also use another license. But as all other presage crates are already licensed `AGPL-3.0-only`, this would probably not make too much sense.

One should maybe also add an `authors` field.

Ping @boxdot as he wrote most of the store.