### PR TITLE
Deprecate sled store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,7 +2268,7 @@ checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
 
 [[package]]
 name = "presage"
-version = "0.7.0-dev"
+version = "0.8.0-dev"
 dependencies = [
  "base64",
  "bytes",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "presage-cli"
-version = "0.6.0-dev"
+version = "0.8.0-dev"
 dependencies = [
  "anyhow",
  "base64",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "presage-store-sled"
-version = "0.6.0-dev"
+version = "0.8.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "presage-store-sqlite"
-version = "0.1.0"
+version = "0.8.0-dev"
 dependencies = [
  "async-trait",
  "bytes",

--- a/presage-cli/Cargo.toml
+++ b/presage-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presage-cli"
-version = "0.6.0-dev"
+version = "0.8.0-dev"
 edition = "2021"
 authors = ["Gabriel Féron <g@leirbag.net>"]
 license = "AGPL-3.0-only"

--- a/presage-cli/src/main.rs
+++ b/presage-cli/src/main.rs
@@ -39,8 +39,6 @@ use presage::{
     store::{Store, Thread},
     Manager,
 };
-use presage_store_sled::MigrationConflictStrategy;
-use presage_store_sled::SledStore;
 use presage_store_sqlite::SqliteStore;
 use tempfile::Builder;
 use tempfile::TempDir;
@@ -55,9 +53,6 @@ use url::Url;
 #[derive(Parser)]
 #[clap(about = "a basic signal CLI to try things out")]
 struct Args {
-    #[clap(long = "sled-db-path", group = "db")]
-    sled_db_path: Option<PathBuf>,
-
     #[clap(long = "sqlite-db-path", group = "db")]
     sqlite_db_path: Option<String>,
 
@@ -236,36 +231,24 @@ fn init() -> Args {
 async fn main() -> anyhow::Result<()> {
     let args = init();
 
-    if let Some(sled_db_path) = args.sled_db_path {
-        debug!(sled_db_path =% sled_db_path.display(), "opening config database");
-        let config_store = SledStore::open_with_passphrase(
-            sled_db_path,
-            args.passphrase,
-            MigrationConflictStrategy::Raise,
-            OnNewIdentity::Trust,
-        )
-        .await?;
+    let sqlite_db_path = args.sqlite_db_path.unwrap_or_else(|| {
+        ProjectDirs::from("org", "whisperfish", "presage")
+            .unwrap()
+            .config_dir()
+            .join("cli.db3")
+            .display()
+            .to_string()
+    });
 
-        run(args.subcommand, config_store).await
-    } else {
-        let sqlite_db_path = args.sqlite_db_path.unwrap_or_else(|| {
-            ProjectDirs::from("org", "whisperfish", "presage")
-                .unwrap()
-                .config_dir()
-                .join("cli.db3")
-                .display()
-                .to_string()
-        });
-        debug!(sqlite_db_path, "opening config database");
-        let config_store = SqliteStore::open_with_passphrase(
-            &sqlite_db_path,
-            args.passphrase.as_deref(),
-            OnNewIdentity::Trust,
-        )
-        .await?;
+    debug!(sqlite_db_path, "opening config database");
+    let config_store = SqliteStore::open_with_passphrase(
+        &sqlite_db_path,
+        args.passphrase.as_deref(),
+        OnNewIdentity::Trust,
+    )
+    .await?;
 
-        run(args.subcommand, config_store).await
-    }
+    run(args.subcommand, config_store).await
 }
 
 async fn send<S: Store>(

--- a/presage-store-sled/Cargo.toml
+++ b/presage-store-sled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presage-store-sled"
-version = "0.6.0-dev"
+version = "0.8.0-dev"
 edition = "2021"
 authors = ["Gabriel Féron <g@leirbag.net>"]
 license = "AGPL-3.0-only"

--- a/presage-store-sled/src/content.rs
+++ b/presage-store-sled/src/content.rs
@@ -20,6 +20,7 @@ use sha2::{Digest, Sha256};
 use sled::IVec;
 use tracing::{debug, trace};
 
+#[allow(deprecated)]
 use crate::{protobuf::ContentProto, SledStore, SledStoreError};
 
 const SLED_TREE_PROFILE_AVATARS: &str = "profile_avatars";
@@ -31,6 +32,7 @@ const SLED_TREE_GROUPS: &str = "groups";
 const SLED_TREE_PROFILES: &str = "profiles";
 const SLED_TREE_THREADS_PREFIX: &str = "threads";
 
+#[allow(deprecated)]
 impl ContentsStore for SledStore {
     type ContentsStoreError = SledStoreError;
 
@@ -80,6 +82,7 @@ impl ContentsStore for SledStore {
         Ok(SledContactsIter {
             iter: self.read().open_tree(SLED_TREE_CONTACTS)?.iter(),
             #[cfg(feature = "encryption")]
+            #[allow(deprecated)]
             cipher: self.cipher.clone(),
         })
     }
@@ -101,6 +104,7 @@ impl ContentsStore for SledStore {
         Ok(SledGroupsIter {
             iter: self.read().open_tree(SLED_TREE_GROUPS)?.iter(),
             #[cfg(feature = "encryption")]
+            #[allow(deprecated)]
             cipher: self.cipher.clone(),
         })
     }
@@ -231,6 +235,7 @@ impl ContentsStore for SledStore {
 
         Ok(SledMessagesIter {
             #[cfg(feature = "encryption")]
+            #[allow(deprecated)]
             cipher: self.cipher.clone(),
             iter,
         })
@@ -303,6 +308,7 @@ impl ContentsStore for SledStore {
 
     async fn sticker_packs(&self) -> Result<Self::StickerPacksIter, SledStoreError> {
         Ok(SledStickerPacksIter {
+            #[allow(deprecated)]
             cipher: self.cipher.clone(),
             iter: self.read().open_tree(SLED_TREE_STICKER_PACKS)?.iter(),
         })

--- a/presage-store-sled/src/lib.rs
+++ b/presage-store-sled/src/lib.rs
@@ -41,6 +41,10 @@ const SLED_KEY_STORE_CIPHER: &str = "store_cipher";
 const SLED_KEY_SENDER_CERTIFICATE: &str = "sender_certificate";
 
 #[derive(Clone)]
+#[deprecated(
+    since = "0.8.0",
+    note = "The sled store is deprecated, use the `presage-store-sqlite` crate instead. This will be removed in a future release. A migration path might be provided before removal if there is demand for it."
+)]
 pub struct SledStore {
     db: Arc<RwLock<sled::Db>>,
     #[cfg(feature = "encryption")]
@@ -99,6 +103,7 @@ impl SchemaVersion {
     }
 }
 
+#[allow(deprecated)]
 impl SledStore {
     #[allow(unused_variables)]
     fn new(
@@ -313,6 +318,7 @@ async fn migrate(
     let passphrase = passphrase.as_ref();
 
     let run_migrations = {
+        #[allow(deprecated)]
         let mut store = SledStore::new(db_path, passphrase, OnNewIdentity::Reject)?;
         let schema_version = store.schema_version();
         for step in schema_version.steps() {
@@ -390,6 +396,7 @@ async fn migrate(
                 }
                 SchemaVersion::V6 => {
                     debug!("migrating from schema v5 to v6: new keys encoding in ACI and PNI protocol stores");
+                    #[allow(deprecated)]
                     let db = store.db.read().expect("poisoned");
 
                     let trees = [
@@ -457,6 +464,7 @@ async fn migrate(
     Ok(())
 }
 
+#[allow(deprecated)]
 impl StateStore for SledStore {
     type StateStoreError = SledStoreError;
 
@@ -533,6 +541,7 @@ impl StateStore for SledStore {
     }
 }
 
+#[allow(deprecated)]
 impl Store for SledStore {
     type Error = SledStoreError;
     type AciStore = SledProtocolStore<AciSledStore>;
@@ -655,6 +664,7 @@ mod tests {
 
     #[quickcheck_async::tokio]
     async fn test_store_messages(thread: Thread, content: Content) -> anyhow::Result<()> {
+        #[allow(deprecated)]
         let db = SledStore::temporary()?;
         let thread = thread.0;
         db.save_message(&thread, content_with_timestamp(&content, 1678295210))

--- a/presage-store-sled/src/protocol.rs
+++ b/presage-store-sled/src/protocol.rs
@@ -22,15 +22,18 @@ use presage::{
 use sled::Batch;
 use tracing::{error, trace, warn};
 
+#[allow(deprecated)]
 use crate::{OnNewIdentity, SledStore, SledStoreError};
 
 #[derive(Clone)]
 pub struct SledProtocolStore<T: SledTrees> {
+    #[allow(deprecated)]
     pub(crate) store: SledStore,
     _trees: PhantomData<T>,
 }
 
 impl SledProtocolStore<AciSledStore> {
+    #[allow(deprecated)]
     pub(crate) fn aci_protocol_store(store: SledStore) -> Self {
         Self {
             store,
@@ -40,6 +43,7 @@ impl SledProtocolStore<AciSledStore> {
 }
 
 impl SledProtocolStore<PniSledStore> {
+    #[allow(deprecated)]
     pub(crate) fn pni_protocol_store(store: SledStore) -> Self {
         Self {
             store,
@@ -50,6 +54,7 @@ impl SledProtocolStore<PniSledStore> {
 
 impl<T: SledTrees> SledProtocolStore<T> {
     fn max_key_id(&self, tree: &str) -> Result<Option<u32>, SignalProtocolError> {
+        #[allow(deprecated)]
         let tree = self
             .store
             .db
@@ -180,6 +185,7 @@ impl SledPreKeyId for KyberPreKeyId {}
 
 impl<T: SledTrees> SledProtocolStore<T> {
     pub(crate) fn clear(&self, clear_sessions: bool) -> Result<(), SledStoreError> {
+        #[allow(deprecated)]
         let db = self.store.db.write().expect("poisoned mutex");
         db.drop_tree(T::pre_keys())?;
         db.drop_tree(T::sender_keys())?;
@@ -247,6 +253,7 @@ impl<T: SledTrees> PreKeysStore for SledProtocolStore<T> {
     }
 
     async fn signed_pre_keys_count(&self) -> Result<usize, SignalProtocolError> {
+        #[allow(deprecated)]
         Ok(self
             .store
             .db
@@ -265,6 +272,7 @@ impl<T: SledTrees> PreKeysStore for SledProtocolStore<T> {
 
     /// number of kyber pre-keys we currently have in store
     async fn kyber_pre_keys_count(&self, last_resort: bool) -> Result<usize, SignalProtocolError> {
+        #[allow(deprecated)]
         Ok(self
             .store
             .db
@@ -612,6 +620,7 @@ impl<T: SledTrees> IdentityKeyStore for SledProtocolStore<T> {
                 if left_identity_key == *right_identity_key {
                     Ok(true)
                 } else {
+                    #[allow(deprecated)]
                     match self.store.trust_new_identities {
                         OnNewIdentity::Trust => Ok(true),
                         OnNewIdentity::Reject => Ok(false),
@@ -722,6 +731,7 @@ mod tests {
 
     #[quickcheck_async::tokio]
     async fn test_save_get_trust_identity(addr: ProtocolAddress, key_pair: KeyPair) -> bool {
+        #[allow(deprecated)]
         let mut db = SledStore::temporary().unwrap().aci_protocol_store();
         let identity_key = protocol::IdentityKey::new(key_pair.0.public_key);
         db.save_identity(&addr.0, &identity_key).await.unwrap();
@@ -738,6 +748,7 @@ mod tests {
     async fn test_store_load_session(addr: ProtocolAddress) -> bool {
         let session = SessionRecord::new_fresh();
 
+        #[allow(deprecated)]
         let mut db = SledStore::temporary().unwrap().aci_protocol_store();
         db.store_session(&addr.0, &session).await.unwrap();
         if db.load_session(&addr.0).await.unwrap().is_none() {
@@ -750,6 +761,7 @@ mod tests {
     #[quickcheck_async::tokio]
     async fn test_prekey_store(id: u32, key_pair: KeyPair) -> bool {
         let id = id.into();
+        #[allow(deprecated)]
         let mut db = SledStore::temporary().unwrap().aci_protocol_store();
         let pre_key_record = PreKeyRecord::new(id, &key_pair.0);
         db.save_pre_key(id, &pre_key_record).await.unwrap();
@@ -770,6 +782,7 @@ mod tests {
         key_pair: KeyPair,
         signature: Vec<u8>,
     ) -> bool {
+        #[allow(deprecated)]
         let mut db = SledStore::temporary().unwrap().aci_protocol_store();
         let id = id.into();
         let signed_pre_key_record = SignedPreKeyRecord::new(
@@ -825,6 +838,7 @@ mod tests {
         key2: ArbPreKeyRecord,
         signed_key: ArbSignedPreKeyRecord,
     ) {
+        #[allow(deprecated)]
         let db = SledStore::temporary().unwrap();
         let mut store = db.aci_protocol_store();
 
@@ -852,6 +866,7 @@ mod tests {
 
     #[quickcheck_async::tokio]
     async fn test_next_key_id_is_max(keys: Vec<u32>, record: ArbPreKeyRecord) -> TestResult {
+        #[allow(deprecated)]
         let db = SledStore::temporary().unwrap();
         let mut store = db.aci_protocol_store();
 

--- a/presage-store-sled/src/protocol.rs
+++ b/presage-store-sled/src/protocol.rs
@@ -696,6 +696,7 @@ mod tests {
     };
     use quickcheck::{Arbitrary, Gen, TestResult};
 
+    #[allow(deprecated)]
     use super::SledStore;
 
     #[derive(Debug, Clone)]

--- a/presage-store-sqlite/Cargo.toml
+++ b/presage-store-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presage-store-sqlite"
-version = "0.1.0"
+version = "0.8.0-dev"
 edition = "2024"
 license = "AGPL-3.0-only"
 

--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # be a sign or warning of (an imminent event, typically an unwelcome one).
 name = "presage"
-version = "0.7.0-dev"
+version = "0.8.0-dev"
 authors = ["Gabriel Féron <g@leirbag.net>"]
 edition = "2021"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
The `sled` store is deprecated (mostly because the crate has been inactive for too long now, and makes our life harder since it's not easy to migrate the schema). The recommended store is now `presage-store-sqlite`.

Closes https://github.com/whisperfish/presage/issues/330