### PR TITLE
Fix sqlite profile key store querying

### DIFF
--- a/presage-store-sqlite/src/content.rs
+++ b/presage-store-sqlite/src/content.rs
@@ -475,8 +475,8 @@ impl ContentsStore for SqliteStore {
         &self,
         service_id: &ServiceId,
     ) -> Result<Option<ProfileKey>, Self::ContentsStoreError> {
-        let service_id = service_id.service_id_string();
-        let profile_key = query_scalar!("SELECT key FROM profile_keys WHERE uuid = ?", service_id)
+        let uuid = service_id.raw_uuid();
+        let profile_key = query_scalar!("SELECT key FROM profile_keys WHERE uuid = ?", uuid)
             .fetch_optional(&self.db)
             .await?
             .and_then(|bytes| bytes.try_into().ok().map(ProfileKey::create));


### PR DESCRIPTION
Previously, any calls to `profile_key` on the sqlite store returned `None`, which lead to all messages being sent identified. This causes issues with rate limiting. The underlying issue was that we query the profile key from the UUID given as string, while we insert the profile key from the UUID given as raw bytes (I think at least that is the issue, I'm not sure how sqlx internally handles it). The fix itself is pretty simple: Convert the `ServiceId` to a `Uuid` and query on that, instead of converting it to a String.

Ideally (at least I think), we should change the interface of the store to take `Uuid` (or even an `Aci` itself) instead of a `ServiceId`, as we only seem to query profile keys based on `Aci`.