### PR TITLE
Migrate doc tests to use sqlite store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,7 +2709,7 @@ dependencies = [
  "futures",
  "hex",
  "libsignal-service",
- "presage-store-sled",
+ "presage-store-sqlite",
  "quickcheck",
  "quickcheck_async",
  "rand 0.9.2",

--- a/presage-cli/Cargo.toml
+++ b/presage-cli/Cargo.toml
@@ -24,7 +24,7 @@ mime_guess = "2.0"
 notify-rust = "4.10.0"
 qr2term = { version = "0.3.1" }
 tempfile = "3.9"
-tokio = { version = "1.43", features = [
+tokio = { version = "1.48", features = [
     "macros",
     "rt-multi-thread",
     "io-std",

--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -17,7 +17,7 @@ serde = "1.0"
 serde_json = "1.0"
 sha2 = "0.10.8"
 thiserror = "1.0"
-tokio = { version = "1.43", default-features = false, features = [
+tokio = { version = "1.48", default-features = false, features = [
     "rt",
     "sync",
     "time",
@@ -30,4 +30,5 @@ bytes = { version = "1.7.2", features = ["serde"] }
 [dev-dependencies]
 quickcheck = "1.0.3"
 quickcheck_async = "0.1"
-presage-store-sled = { path = "../presage-store-sled" }
+presage-store-sqlite = { path = "../presage-store-sqlite" }
+tokio = { version = "1.48.0", features = ["rt-multi-thread", "macros"] }

--- a/presage/src/manager/linking.rs
+++ b/presage/src/manager/linking.rs
@@ -33,12 +33,11 @@ impl<S: Store> Manager<S, Linking> {
     /// use presage::libsignal_service::configuration::SignalServers;
     /// use presage::Manager;
     /// use presage::model::identity::OnNewIdentity;
-    /// use presage_store_sled::{MigrationConflictStrategy, SledStore};
+    /// use presage_store_sqlite::SqliteStore;
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let store =
-    ///         SledStore::open("/tmp/presage-example", MigrationConflictStrategy::Drop, OnNewIdentity::Trust).await?;
+    ///     let store = SqliteStore::open(":memory:", OnNewIdentity::Trust).await?;
     ///
     ///     let (mut tx, mut rx) = oneshot::channel();
     ///     let (manager, err) = future::join(

--- a/presage/src/manager/registration.rs
+++ b/presage/src/manager/registration.rs
@@ -40,12 +40,11 @@ impl<S: Store> Manager<S, Registration> {
     /// use presage::Manager;
     /// use presage::model::identity::OnNewIdentity;
     ///
-    /// use presage_store_sled::{MigrationConflictStrategy, SledStore};
+    /// use presage_store_sqlite::SqliteStore;
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let store =
-    ///         SledStore::open("/tmp/presage-example", MigrationConflictStrategy::Drop, OnNewIdentity::Trust).await?;
+    ///     let store = SqliteStore::open(":memory:", OnNewIdentity::Trust).await?;
     ///
     ///     let manager = Manager::register(
     ///         store,


### PR DESCRIPTION
They previously used the sled store, which has been deprecated for a while now. This commit pretty much just replaces the store in the doc tests with the sqlite store. While implementing it, I also noticed that running the doc tests in the `presage` crate instead of in the workspace also leads to errors as tokio a feature (`rt-multi-thread`) is used that is only enabled in another crate (`presage-cli`). I therefore also added tokio separately as a dev dependency with that feature enabled. Doing that, I also noticed we are using two separate tokio versions (at least in the `Cargo.toml` files, they are unified by Rust later), I therefore replaced the old version with the new one as well.