### PR TITLE
Actually encrypt the sqlite store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,6 +2797,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "libsqlite3-sys",
  "presage",
  "prost",
  "rand 0.9.2",

--- a/presage-store-sqlite/Cargo.toml
+++ b/presage-store-sqlite/Cargo.toml
@@ -17,6 +17,9 @@ thiserror = "2.0.0"
 tracing = "0.1.41"
 uuid = "1.12.0"
 
+# Explicitly use the libsqlite3-sys crate with the bundled-sqlcipher feature
+libsqlite3-sys = { version = "0.30", features = ["bundled-sqlcipher"] }
+
 [dev-dependencies]
 tokio = { version = "1.48.0", features = ["rt", "macros"] }
 rand = "0.9"

--- a/presage-store-sqlite/src/error.rs
+++ b/presage-store-sqlite/src/error.rs
@@ -13,6 +13,8 @@ pub enum SqliteStoreError {
     #[error(transparent)]
     Db(#[from] sqlx::Error),
     #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
     Migrate(#[from] sqlx::migrate::MigrateError),
     #[error(transparent)]
     Json(#[from] serde_json::Error),

--- a/presage-store-sqlite/src/lib.rs
+++ b/presage-store-sqlite/src/lib.rs
@@ -34,15 +34,42 @@ impl SqliteStore {
         passphrase: Option<&str>,
         trust_new_identities: OnNewIdentity,
     ) -> Result<Self, SqliteStoreError> {
+        // Escape the passphrase.
+        let passphrase = passphrase.map(|p| p.replace("'", "''"));
+
         let options: SqliteConnectOptions = url.parse()?;
         let options = options.create_if_missing(true).foreign_keys(true);
-        let options = if let Some(passphrase) = passphrase {
-            let passphrase = passphrase.replace("'", "''");
+        let options = if let Some(passphrase) = &passphrase {
             options.pragma("key", format!("'{passphrase}'"))
         } else {
             options
         };
-        Self::open_with_options(options, trust_new_identities).await
+        match Self::open_with_options(options.clone(), trust_new_identities.clone()).await {
+            Ok(s) => Ok(s),
+            // The error "file is not a database" (error code 26) could mean that we provided a key for decrypting the database, but the database was actually not encrypted due to a bug in earlier versions of presage-store-sqlite.
+            // If that is the case, try to migrate the database to be encrypted.
+            Err(SqliteStoreError::Migrate(sqlx::migrate::MigrateError::Execute(
+                sqlx::Error::Database(e),
+            ))) if e.code().is_some_and(|c| c.as_ref() == "26") => {
+                // Attempting migration only makes sense if a passphrase is given, otherwise just return the error.
+                let Some(passphrase) = passphrase else {
+                    return Err(SqliteStoreError::Migrate(
+                        sqlx::migrate::MigrateError::Execute(sqlx::Error::Database(e)),
+                    ));
+                };
+
+                // It does not make sense to try a migration of an in-memory database.
+                // Also abort in that case.
+                if url == ":memory:" {
+                    return Err(SqliteStoreError::Migrate(
+                        sqlx::migrate::MigrateError::Execute(sqlx::Error::Database(e)),
+                    ));
+                }
+
+                Self::open_migrate_to_encrypted(url, &passphrase, trust_new_identities).await
+            }
+            Err(e) => Err(e),
+        }
     }
 
     pub async fn open_with_options(
@@ -55,6 +82,55 @@ impl SqliteStore {
             db,
             trust_new_identities,
         })
+    }
+
+    /// There sadly does not seem to be a good migration strategy contained within the database we are trying to migrate.
+    /// The general migration strategy is therefore creating a new encrypted database, copy the data from the unencrypted to the encrypted database, and then replace the unencrypted database with the encrypted one.
+    /// The details can be found in this comment: <https://github.com/davidmartos96/sqflite_sqlcipher/issues/20#issuecomment-634167760>.
+    ///
+    /// This assumes that the passphrase is escaped (i.e. all `'` are already replaced by `''`).
+    async fn open_migrate_to_encrypted(
+        url: &str,
+        passphrase: &str,
+        trust_new_identities: OnNewIdentity,
+    ) -> Result<Self, SqliteStoreError> {
+        tracing::info!("Attempting to migrate an unencrypted sqlite store to an encrypted one");
+        // The place where the encrypted database will be temporarily stored.
+        let encrypted_url = format!("{url}.encrypted");
+
+        // Try to open the database to migrate without any encryption.
+        let no_password_options: SqliteConnectOptions = url.parse()?;
+        let no_password_options = no_password_options
+            .create_if_missing(true)
+            .foreign_keys(true);
+        let no_password_db =
+            Self::open_with_options(no_password_options, trust_new_identities.clone()).await?;
+
+        // Execute the migration.
+        // This cannot be done in an sqlx macro way checking that the sql code is actually correct, as the macro does not seem to have `sqlcipher_export` available.
+        // Note that `raw_sql` does not support query parameters (https://docs.rs/sqlx/latest/sqlx/fn.raw_sql.html#note-query-parameters-are-not-supported).
+        // Therefore, in theory, an sql-injection could be possible.
+        // But we escape the `encrypted_url`, and assume the passphrase to already be escaped, so I don't think an injection is actually possible.
+        sqlx::raw_sql(&format!(
+            "ATTACH DATABASE '{}' AS encrypted KEY '{passphrase}';
+            SELECT sqlcipher_export('encrypted');
+            DETACH DATABASE encrypted;",
+            encrypted_url.replace("'", "''")
+        ))
+        .execute(&no_password_db.db)
+        .await?;
+
+        drop(no_password_db);
+
+        // Replace the unencrypted database with the encrypted one.
+        // TODO: Maybe zero out the unencrypted URL before?
+        std::fs::rename(encrypted_url, url)?;
+
+        // Return the now encrypted store.
+        let options: SqliteConnectOptions = url.parse()?;
+        let options = options.create_if_missing(true).foreign_keys(true);
+        let options = options.pragma("key", format!("'{passphrase}'"));
+        Self::open_with_options(options, trust_new_identities).await
     }
 }
 


### PR DESCRIPTION
We previously did not encrypt the sqlite store as we did not have libsqlite3 with bundled sqlite-cipher. #335 tried to change that, but that was not backwards compatible, and had to be reverted in #337. This commit now enables the encryption as already done in #335, but also provides a migration strategy. Sadly, migration is not as easy as just defining an sqlx migration, and instead requires creating a new encrypted database, moving everything from the unencrypted to the encrypted store, and finally replacing the unencrypted store with the encrypted one. The details are non-trivial, and layed out as comments in the actual code.