### PR TITLE
hotfix(deps): include new sealed trusted roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,7 +1892,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=abad1634f91dba01baefc55b2a6196be00635b55#abad1634f91dba01baefc55b2a6196be00635b55"
+source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=b48b42fbce755035fafafc3b28d5b23844763e49#b48b42fbce755035fafafc3b28d5b23844763e49"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "AGPL-3.0-only"
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "abad1634f91dba01baefc55b2a6196be00635b55" }
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "b48b42fbce755035fafafc3b28d5b23844763e49" }
 
 base64 = "0.22"
 futures = "0.3"

--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -1229,7 +1229,7 @@ impl<S: Store> Manager<S, Registered> {
             self.store.aci_protocol_store(),
             self.state
                 .service_configuration()
-                .unidentified_sender_trust_root,
+                .unidentified_sender_trust_roots,
             self.state.data.service_ids.aci,
             self.state.device_id(),
         )
@@ -1240,7 +1240,7 @@ impl<S: Store> Manager<S, Registered> {
             self.store.pni_protocol_store(),
             self.state
                 .service_configuration()
-                .unidentified_sender_trust_root,
+                .unidentified_sender_trust_roots,
             self.state.data.service_ids.pni,
             self.state.device_id(),
         )


### PR DESCRIPTION
Note: this does not include whisperfish/libsignal-service-rs#366 from the main branch.