### PR TITLE
Added display of data_message.preview

### DIFF
--- a/presage-cli/src/main.rs
+++ b/presage-cli/src/main.rs
@@ -381,16 +381,20 @@ async fn print_message<S: Store>(
         if !data_message.preview.is_empty() {
             preview_appendix = "\nLink previews:".to_string();
             for (i, preview) in data_message.preview.iter().enumerate() {
-                preview_appendix += &format!("\n(link #{}) url: {}; title: {}; description: {}; date: {}; ",
-                                             i+1,
-                                             preview.url.clone().unwrap_or("None".to_string()),
-                                             preview.title.clone().unwrap_or("None".to_string()),
-                                             preview.description.clone().unwrap_or("None".to_string()),
-                                             preview.date.clone().and_then(|x| Some(x.to_string())).unwrap_or("None".to_string()),
+                preview_appendix += &format!(
+                    "\n(link #{}) url: {}; title: {}; description: {}; date: {}; ",
+                    i + 1,
+                    preview.url.as_deref().unwrap_or("None"),
+                    preview.title.as_deref().unwrap_or("None"),
+                    preview.description.as_deref().unwrap_or("None"),
+                    preview
+                        .date
+                        .map(|x| x.to_string())
+                        .unwrap_or("None".to_string()),
                 )
             }
         }
-        
+
         match data_message {
             DataMessage {
                 quote:
@@ -400,7 +404,9 @@ async fn print_message<S: Store>(
                     }),
                 body: Some(body),
                 ..
-            } => Some(format!("Answer to message \"{quoted_text}\": {body}{preview_appendix}")),
+            } => Some(format!(
+                "Answer to message \"{quoted_text}\": {body}{preview_appendix}"
+            )),
             DataMessage {
                 reaction:
                     Some(Reaction {


### PR DESCRIPTION
I updated the `format_data_message` function to display the `DataMessage`'s previews. 
- I made some assumptions about how the previews would best match the current formatting of incoming messages. Currently each preview is displayed on a new line. All fields are printed but `image`, as I was not sure how to best render the `AttachmentPointer`.
- Since now the printed message consists of a `body` and potentially `preview`, I thought it could be a good idea to wrap the former, for example with a `==BEGIN MESSAGE==` and `==BEGIN MESSAGE==` header and tailer, respectively, to differentiate a message that has something that looks like a preview display at the end of its body, from a message that really has a preview, but that seemed like a pretty big change.

Related to https://github.com/whisperfish/presage/issues/356