### PR TITLE
feat: Add url previews to outgoing messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +588,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex 2.0.1",
 ]
 
@@ -779,6 +803,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -917,6 +951,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1122,6 +1179,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1224,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1249,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -1366,6 +1459,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,6 +1588,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1748,6 +1860,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "html5ever"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
+dependencies = [
+ "log",
+ "markup5ever",
+]
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,9 +1978,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2086,6 +2210,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
 ]
 
 [[package]]
@@ -2344,7 +2478,7 @@ dependencies = [
  "rand 0.9.5",
  "rand_core 0.9.5",
  "rustls",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "scopeguard",
  "serde",
  "serde_json",
@@ -2400,7 +2534,7 @@ dependencies = [
  "rand_core 0.9.5",
  "rangemap",
  "rustls",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "snow",
  "static_assertions",
  "strum",
@@ -2484,7 +2618,7 @@ dependencies = [
  "prost-build",
  "rand 0.9.5",
  "rand_core 0.6.4",
- "reqwest",
+ "reqwest 0.12.28",
  "reqwest-websocket",
  "serde",
  "serde_json",
@@ -2585,6 +2719,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
 name = "mac-notification-sys"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2596,6 +2736,17 @@ dependencies = [
  "objc2-foundation",
  "time",
  "uuid",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
 ]
 
 [[package]]
@@ -2670,6 +2821,12 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"
@@ -2956,6 +3113,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "phonenumber"
 version = "0.3.10+9.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,6 +3323,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "presage"
 version = "0.8.0-dev"
 dependencies = [
@@ -3123,10 +3339,14 @@ dependencies = [
  "futures",
  "hex",
  "libsignal-service",
+ "mime",
  "presage-store-sqlite",
  "quickcheck",
  "quickcheck_async",
  "rand 0.9.5",
+ "regex",
+ "reqwest 0.13.2",
+ "scraper",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -3401,6 +3621,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -3672,6 +3893,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier 0.6.2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "reqwest-websocket"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3679,7 +3938,7 @@ checksum = "f477f800f86d8f5c320e19d8b2b1ef0b1e773ea7c75eec6c7f442e7ec3f06d7e"
 dependencies = [
  "async-tungstenite",
  "futures-util",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3751,6 +4010,7 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3787,7 +4047,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -3803,6 +4063,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs 1.0.8",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3814,6 +4095,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3856,13 +4138,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93cecd86d6259499c844440546d02f55f3e17bd286e529e48d1f9f67e92315cb"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3876,6 +4173,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -3948,6 +4264,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -4069,6 +4394,12 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -4355,6 +4686,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4441,6 +4796,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tauri-winrt-notification"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4462,6 +4838,17 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -4918,6 +5305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5154,6 +5547,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5321,6 +5726,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -34,6 +34,10 @@ tracing = "0.1"
 url = "2.5"
 derive_more = { version = "2.1.0", features = ["debug"] }
 bytes = { version = "1.7.2", features = ["serde"] }
+mime = "0.3.17"
+regex = "1.12.2"
+reqwest = "0.13.1"
+scraper = "0.25.0"
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -55,6 +55,7 @@ use tracing::{debug, error, info, trace, warn};
 use url::Url;
 
 use crate::model::contacts::Contact;
+use crate::model::previews;
 use crate::serde::serde_profile_key;
 use crate::store::{ContentsStore, Sticker, StickerPack, StickerPackManifest, Store, Thread};
 use crate::{model::groups::Group, AvatarBytes, Error, Manager};
@@ -1134,7 +1135,10 @@ impl<S: Store> Manager<S, Registered> {
             });
 
         // we need to put our profile key in DataMessage
+
         if let ContentBody::DataMessage(message) = &mut content_body {
+            let body = message.body.clone().unwrap_or_default();
+            message.preview = self.build_protobuf_preview(&body).await;
             message
                 .profile_key
                 .get_or_insert(self.state.data.profile_key().get_bytes().to_vec());
@@ -1183,6 +1187,33 @@ impl<S: Store> Manager<S, Registered> {
         Ok(())
     }
 
+    /// Extracts URLs from `body`, fetches a preview (title, description, image) for each, and
+    /// uploads any preview image as an attachment, ready to be attached to a `DataMessage` as
+    /// its `preview` field. Used by both `send_message` and `send_message_to_group`.
+    async fn build_protobuf_preview(&self, body: &str) -> Vec<libsignal_service::proto::Preview> {
+        let preview_contents = previews::generate_previews_from_message(body).await;
+
+        future::join_all(preview_contents.iter().map(|content| async {
+            let image = match previews::build_preview_image(content) {
+                Some((spec, bytes)) => self
+                    .upload_attachment(spec, bytes)
+                    .await
+                    .ok()
+                    .and_then(Result::ok),
+                None => None,
+            };
+
+            libsignal_service::proto::Preview {
+                url: content.url.clone(),
+                title: content.title.clone(),
+                image,
+                description: content.description.clone(),
+                date: content.date,
+            }
+        }))
+        .await
+    }
+
     /// Uploads one attachment prior to linking them in a message.
     pub async fn upload_attachment(
         &self,
@@ -1229,6 +1260,10 @@ impl<S: Store> Manager<S, Registered> {
         let thread = Thread::Group(master_key_bytes);
 
         self.restore_thread_timer(&thread, &mut content_body).await;
+        if let ContentBody::DataMessage(message) = &mut content_body {
+            let body = message.body.clone().unwrap_or_default();
+            message.preview = self.build_protobuf_preview(&body).await;
+        }
         ensure_data_message_timestamp(&mut content_body, timestamp);
 
         let mut sender = self.new_message_sender().await?;

--- a/presage/src/model/mod.rs
+++ b/presage/src/model/mod.rs
@@ -5,6 +5,7 @@ pub mod contacts;
 pub mod groups;
 pub mod identity;
 pub mod messages;
+pub mod previews;
 
 #[derive(Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub enum ServiceIdType {

--- a/presage/src/model/previews.rs
+++ b/presage/src/model/previews.rs
@@ -1,0 +1,434 @@
+use futures::stream::{self, StreamExt};
+use libsignal_service::sender::AttachmentSpec;
+use mime::Mime;
+use regex::Regex;
+use reqwest::header::CONTENT_TYPE;
+use reqwest::IntoUrl;
+use scraper::{Html, Selector};
+use std::str::FromStr;
+use url::Url;
+
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("Reqwest error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("The response does not contain a Content-Type header")]
+    MissingContentTypeHeadersError,
+    //#[error("Err error: {0}")]
+    //ConversionError,
+    #[error("Err error: {0}")]
+    UnsupportedMimeTypeError(String),
+    #[error("Downloaded file does not look like an image")]
+    NonImageBytesError,
+    #[error("ToStr error: {0}")]
+    ToStrtError(#[from] reqwest::header::ToStrError),
+    #[error("FromStr error: {0}")]
+    FromStrError(#[from] mime::FromStrError),
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct PreviewContent {
+    pub url: Option<String>,
+    pub title: Option<String>,
+    pub image: Option<Vec<u8>>,
+    /// The MIME (e.g. `image/jpeg`) of `image`, detected from the response's
+    /// `Content-Type` header or, failing that, sniffed from the image bytes themselves:
+    pub image_content_type: Option<String>,
+    pub description: Option<String>,
+    pub date: Option<u64>,
+}
+
+pub async fn generate_preview_from_url<T: IntoUrl>(
+    url: T,
+    client: &reqwest::Client,
+) -> Result<PreviewContent, Error> {
+    let url = url.into_url()?;
+    // a default url value in case the og:url tag is missing
+    let default_url_preview = url.clone().host_str().map(|y| y.to_string());
+
+    let mut preview: PreviewContent = {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("user-agent", "WhatsApp/2".parse().unwrap());
+
+        let response = client
+            .get(url)
+            .headers(headers)
+            .send()
+            .await?
+            .error_for_status()?;
+
+        let headers = &response.headers();
+
+        match headers.get(CONTENT_TYPE) {
+            None => return Err(Error::MissingContentTypeHeadersError),
+            Some(content_type) => {
+                let content_type = content_type.to_str()?;
+                let content_type = Mime::from_str(content_type)?;
+                match (content_type.type_(), content_type.subtype()) {
+                    (mime::TEXT, mime::HTML) => {
+                        let html = response.text().await?;
+                        generate_preview_from_html(&html, client).await
+                    }
+                    (mime::IMAGE, _) => {
+                        let (image, image_content_type) =
+                            match fetch_image_from_response(response).await {
+                                Ok((bytes, content_type)) => (Some(bytes), Some(content_type)),
+                                Err(_) => (None, None),
+                            };
+                        PreviewContent {
+                            url: None,
+                            title: None,
+                            image,
+                            image_content_type,
+                            description: None,
+                            date: None,
+                        }
+                    }
+                    _ => {
+                        return Err(Error::UnsupportedMimeTypeError(format!(
+                            "Got unsupported mime type:{}.",
+                            content_type
+                        )))
+                    }
+                }
+            }
+        }
+    };
+
+    if preview.url.is_none() {
+        preview.url = default_url_preview;
+    }
+    Ok(preview)
+}
+
+/// The function builds a Preview primarily from the html's OG tags.
+/// If some of these are unavailable, it resorts to other tags to fill the preview's fields.
+/// The url is taken from the stemmed url of the page.
+/// The title is taken from the <title> tag (if available).
+/// The description is taken from the  <meta name="description"> tag (if available).
+pub async fn generate_preview_from_html(
+    html_doc: &str,
+    client: &reqwest::Client,
+) -> PreviewContent {
+    let document = Html::parse_document(html_doc);
+    let selector = Selector::parse("meta").unwrap();
+    let mut preview = PreviewContent {
+        url: None,
+        title: None,
+        image: None,
+        image_content_type: None,
+        description: None,
+        date: None,
+    };
+
+    for element in document.select(&selector) {
+        // get description from <meta name="description">
+        let name = element
+            .value()
+            .attr("name")
+            .unwrap_or("")
+            .trim()
+            .to_string();
+
+        if (name == "description") && (preview.description.is_none()) {
+            if let Some(c) = element.value().attr("content") {
+                preview.description = Some(c.to_string())
+            }
+        }
+
+        // get fields from <meta property="og:"
+        let property = element.value().attr("property").unwrap_or("").to_string();
+        if let Some(capture) = property.strip_prefix("og:") {
+            let field = capture.trim();
+            let content = element.value().attr("content").unwrap_or("").to_string();
+            match field {
+                "url" => preview.url = Some(content),
+                "title" => preview.title = Some(content),
+                "image" => {
+                    if let Ok((bytes, content_type)) = fetch_image_from_url(content, client).await {
+                        preview.image = Some(bytes);
+                        preview.image_content_type = Some(content_type);
+                    }
+                }
+                "description" => preview.description = Some(content),
+                "date" | "article:published_time" | "article:modified_time" => {
+                    preview.date = std::cmp::max(preview.date, timestamp_from_iso(&content))
+                }
+                _ => (),
+            }
+        }
+
+        // Check whether the preview is still missing any fields; if not, break.
+        // in practice, since date is essentially never set on real pages, this rarely breaks
+        // early and we scan the whole `<head>`.
+        if [
+            preview.url.is_none(),
+            preview.title.is_none(),
+            preview.image.is_none(),
+            preview.description.is_none(),
+            preview.date.is_none(),
+        ]
+        .iter()
+        .all(|&is_missing| !is_missing)
+        {
+            break;
+        }
+    }
+
+    // in case no og:title was found, get the value from <title>
+    if preview.title.is_none() | (preview.title == Some("".to_string())) {
+        let selector = Selector::parse("title").unwrap();
+        let title = document
+            .select(&selector)
+            .next()
+            .map(|x| x.inner_html().trim().to_owned());
+        preview.title = title;
+    }
+    preview
+}
+
+/// The task of extracting urls from a text message is not trivial, since
+/// they might be enclosed within parentheses or be immediately followed
+/// by punctuation. This here function tries to strike a balance, taking
+/// into account that punctuations as well as parentheses might
+/// appear within valid urls.
+pub fn extract_urls_from_text_block(message: &str) -> Vec<Url> {
+    let re = Regex::new(
+        r#"(?xi)
+        \b
+        (
+            (?:https?://)?              # Optional scheme
+            (?:www\.)?
+            [a-z0-9.-]+\.[a-z]{2,}
+            [^\s]*                      # Capture everything until whitespace
+        )
+        "#,
+    )
+    .unwrap();
+
+    let mut urls = Vec::new();
+
+    for cap in re.captures_iter(message) {
+        let mut candidate = cap[1].to_string();
+
+        // Trim wrapping punctuation
+        candidate = candidate
+            .trim_matches(|c: char| {
+                matches!(
+                    c,
+                    '[' | ']' | '{' | '}' | '<' | '>' | '"' | '\'' | ',' | '.' | '!' | '?' | ':'
+                )
+            })
+            .to_string();
+
+        // Balance parentheses
+        loop {
+            let opens = candidate.matches('(').count();
+            let closes = candidate.matches(')').count();
+
+            if closes > opens && candidate.ends_with(')') {
+                // remove closing parenthesis
+                candidate.pop();
+            } else {
+                break;
+            }
+        }
+
+        // Add scheme
+        let url = if candidate.starts_with("http://") || candidate.starts_with("https://") {
+            candidate.clone()
+        } else {
+            format!("https://{}", candidate)
+        };
+
+        if let Ok(url) = Url::parse(&url) {
+            urls.push(url);
+        }
+    }
+    urls
+}
+
+pub async fn generate_previews_from_message(message: &str) -> Vec<PreviewContent> {
+    let urls = extract_urls_from_text_block(message);
+    let client = reqwest::Client::new();
+
+    stream::iter(urls)
+        .map(|url| generate_preview_from_url(url, &client))
+        .buffer_unordered(10)
+        .filter_map(|res| async move { res.ok() })
+        .collect()
+        .await
+}
+
+/// Builds the `AttachmentSpec` and raw bytes needed to upload `content`'s image as an
+/// attachment, e.g. via `Manager::upload_attachment`. Returns `None` if `content` has no image.
+pub fn build_preview_image(content: &PreviewContent) -> Option<(AttachmentSpec, Vec<u8>)> {
+    let image = content.image.as_ref()?;
+    let content_type = content.image_content_type.as_ref()?;
+
+    Some((
+        AttachmentSpec {
+            content_type: content_type.clone(),
+            length: image.len(),
+            file_name: None,
+            preview: None,
+            voice_note: None,
+            borderless: None,
+            width: None,
+            height: None,
+            caption: None,
+            blur_hash: None,
+        },
+        image.clone(),
+    ))
+}
+
+async fn fetch_image_from_url<T: IntoUrl>(
+    url: T,
+    client: &reqwest::Client,
+) -> Result<(Vec<u8>, String), Error> {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert("user-agent", "WhatsApp/2".parse().unwrap());
+
+    let response: reqwest::Response = client
+        .get(url)
+        .headers(headers)
+        .send()
+        .await?
+        .error_for_status()?;
+
+    fetch_image_from_response(response).await
+}
+
+/// Fetches the body of `response`, returning its bytes along with the detected image MIME
+/// (e.g. `image/jpeg`), preferring the response's own `Content-Type` header and falling
+/// back to sniffing the file signature when that header is missing or not an image type.
+async fn fetch_image_from_response(
+    response: reqwest::Response,
+) -> Result<(Vec<u8>, String), Error> {
+    let header_content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| Mime::from_str(value).ok())
+        .filter(|mime| mime.type_() == mime::IMAGE)
+        .map(|mime| mime.essence_str().to_string());
+
+    let bytes = response.bytes().await?;
+
+    let Some(content_type) =
+        header_content_type.or_else(|| sniff_image_mime_type(&bytes).map(str::to_string))
+    else {
+        return Err(Error::NonImageBytesError);
+    };
+
+    Ok((bytes.into(), content_type))
+}
+
+fn timestamp_from_iso(datetime_str: &str) -> Option<u64> {
+    let datetime = chrono::DateTime::parse_from_rfc3339(datetime_str).ok()?;
+    let timestamp = chrono::DateTime::timestamp(&datetime);
+    Some(timestamp as u64)
+}
+
+/// Detects the image MIME essence (e.g. `image/jpeg`) from a file's magic bytes.
+fn sniff_image_mime_type(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        Some("image/jpeg")
+    } else if bytes.starts_with(&[0x89, b'P', b'N', b'G']) {
+        Some("image/png")
+    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        Some("image/gif")
+    } else if bytes.starts_with(b"BM") {
+        Some("image/bmp")
+    } else if bytes.starts_with(b"RIFF") && bytes.get(8..12) == Some(b"WEBP") {
+        Some("image/webp")
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_urls_from_text_block() {
+        assert_eq!(
+            extract_urls_from_text_block("check this out: https://example.com/foo"),
+            vec![Url::parse("https://example.com/foo").unwrap()]
+        );
+
+        assert_eq!(
+            extract_urls_from_text_block("see (https://example.com/foo) for details"),
+            vec![Url::parse("https://example.com/foo").unwrap()]
+        );
+
+        assert_eq!(
+            extract_urls_from_text_block("visit example.com."),
+            vec![Url::parse("https://example.com").unwrap()]
+        );
+
+        assert_eq!(
+            extract_urls_from_text_block("https://a.com and https://b.com/path?x=1"),
+            vec![
+                Url::parse("https://a.com").unwrap(),
+                Url::parse("https://b.com/path?x=1").unwrap()
+            ]
+        );
+
+        assert!(extract_urls_from_text_block("no links in this message").is_empty());
+    }
+
+    #[test]
+    fn test_sniff_image_mime_type() {
+        assert_eq!(
+            sniff_image_mime_type(&[0xFF, 0xD8, 0xFF, 0xE0]),
+            Some("image/jpeg")
+        );
+        assert_eq!(
+            sniff_image_mime_type(b"\x89PNG\r\n\x1a\n"),
+            Some("image/png")
+        );
+        assert_eq!(sniff_image_mime_type(b"GIF89a"), Some("image/gif"));
+        assert_eq!(sniff_image_mime_type(b"BM\0\0\0\0"), Some("image/bmp"));
+        assert_eq!(
+            sniff_image_mime_type(b"RIFF\0\0\0\0WEBPVP8 "),
+            Some("image/webp")
+        );
+        assert_eq!(sniff_image_mime_type(b"not an image"), None);
+    }
+
+    #[tokio::test]
+    async fn test_generate_preview_from_html_uses_og_tags() {
+        let html = r#"
+            <html><head>
+                <meta property="og:title" content="Example title">
+                <meta property="og:description" content="Example description">
+                <title>Fallback title</title>
+            </head></html>
+        "#;
+        let client = reqwest::Client::new();
+        let preview = generate_preview_from_html(html, &client).await;
+
+        assert_eq!(preview.title.as_deref(), Some("Example title"));
+        assert_eq!(preview.description.as_deref(), Some("Example description"));
+        assert!(preview.image.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_generate_preview_from_html_falls_back_to_title_tag() {
+        let html = r#"
+            <html><head>
+                <meta name="description" content="Meta description">
+                <title>  Fallback title  </title>
+            </head></html>
+        "#;
+        let client = reqwest::Client::new();
+        let preview = generate_preview_from_html(html, &client).await;
+
+        assert_eq!(preview.title.as_deref(), Some("Fallback title"));
+        assert_eq!(preview.description.as_deref(), Some("Meta description"));
+    }
+}


### PR DESCRIPTION
The implementation is largely finished, however:
- I have not yet implemented the functionality for `send_message_to_group`.
- While a print statement before the `sender.send_message` block shows that the message contains a populated Preview vector, when sending a message via Presage to either the Linux desktop client or the Android mobile client, no preview is displayed. Since I couldn't send and receive with Presage at the same time (maybe I can spin instances on different sockets in parallel?) I don't know whether the `preview` gets dropped somewhere before being sent or something happens to it when it is received.
- My branch requires a few crates (mime, regex, reqwest, scraper). I suppose these are mostly their dependencies, but `Cargo.lock` has gotten quite a few new lines, and I took the conservative step and left it out of the commit. I felt I should be cautious about it. 

A few questions:
- I read only the parts of the code which were relevant to the task at hand. During this journey I couldn't really divine what the separation between `manager` and `model` was based on. I made a guess that the `previews` should go to `model`, but I don't expect to have gotten it right. I'll be very happy to know where my code fits best and how to best import it.
- I left handling the content of `preview.image`, a `<AttachmentPointer>` to the end. I looked briefly for existing code that could suggest how to build it. I could look further, but if somebody could give me a tip or a pointer as to how to create an <AttachmentPointer> based off a url to an image, it would make my job easier.
- Can anybody tell me what the preview's date field (a `u64`) is for? It is not part of the [the Open Graph protocol](https://ogp.me/)'s specification, and none of the messages that I sent with the official Signal apps had a preview that contained a non-None/ 0 value.

https://github.com/whisperfish/presage/issues/356 