### PR TITLE
Fix refresh registration

### DIFF
--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -900,7 +900,13 @@ impl<S: Store> Manager<S, Registered> {
                         None
                     }
                     future::Either::Left((Ok(_), rx_loop)) => rx_loop.await,
-                    future::Either::Right((rx_loop_result, _)) => rx_loop_result,
+                    future::Either::Right((rx_loop_result, refresh)) => {
+                        if let Err(()) = refresh.await {
+                            error!("FATAL: failed to refresh keys and account attributes!");
+                            return None;
+                        }
+                        rx_loop_result
+                    }
                 }
             }
         })))


### PR DESCRIPTION
Previously, the registration refresh future could get cancelled when a message is received by the incoming messages loop. This commit fixes this by awaiting for the registration refresh future after a message was received.