### PR TITLE
hotfix: tokio::task::spawn_local for refreshing account attributes and pre-keys

### DIFF
--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -560,20 +560,17 @@ impl<S: Store> Manager<S, Registered> {
         //
         // this is necessary because in this context, we can't do the classic tokio::spawn
         // with a oneshot::channel() or CancellationToken because of !Send constraints in the Store.
-        let refresh_registration_task = async move {
+        tokio::task::spawn_local(async move {
             if let Err(error) =
                 set_account_attributes::<S>(&mut account_manager, &registration_data_inner).await
             {
                 error!(%error, "failed to set account attributes, this is problematic and should never happen!");
-                return Some(()); // stop signal
-            } else if let Err(error) = register_pre_keys(&store_inner, &mut account_manager).await {
-                error!(%error, "failed to register pre-keys, this is problematic and should never happen!");
-                return Some(()); // stop signal
             }
 
-            future::pending::<()>().await; // hack: wait forever (non-busy loop)
-            None
-        };
+            if let Err(error) = register_pre_keys(&store_inner, &mut account_manager).await {
+                error!(%error, "failed to register pre-keys, this is problematic and should never happen!");
+            }
+        });
 
         let encrypted_messages = MessagePipe::from_socket(identified_websocket.clone());
 
@@ -888,7 +885,7 @@ impl<S: Store> Manager<S, Registered> {
         Ok(Box::pin(
             // we use the returning of the async closure in take_until as a stop signal
             // if the future resolves *anything* the stream will end
-            incoming_messages_stream.take_until(refresh_registration_task),
+            incoming_messages_stream,
         ))
     }
 


### PR DESCRIPTION
For the time being, until I can figure out a way to fix `set_account_attributes`