### PR TITLE
Bump libsignal-service to fix linking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,7 +2420,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=72669e18498c73c27ba8430db37aee626e549027#72669e18498c73c27ba8430db37aee626e549027"
+source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=3d07d8df33482b2d191c075fdc2b750738a89384#3d07d8df33482b2d191c075fdc2b750738a89384"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -12,7 +12,7 @@ default = ["cdsi"]
 cdsi = ["libsignal-service/cdsi"]
 
 [dependencies]
-libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "72669e18498c73c27ba8430db37aee626e549027", default-features = false, features = [
+libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", rev = "3d07d8df33482b2d191c075fdc2b750738a89384", default-features = false, features = [
     "phonenumber",
 ] }
 


### PR DESCRIPTION
Fixes #385 as well as https://github.com/boxdot/gurk-rs/issues/508 once `presage` is updated there.