### PR TITLE
fix: handle DecryptionErrorMessage variant in save_message

### DIFF
--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -1756,6 +1756,10 @@ async fn save_message<S: Store>(
             debug!(?msg, "invalid edited");
             None
         }
+        ContentBody::DecryptionErrorMessage(msg) => {
+            debug!(?msg, "skipping decryption error message");
+            None
+        }
     };
 
     if let Some(message) = message {


### PR DESCRIPTION
## Summary

`libsignal-service-rs@773cc03` added a `ContentBody::DecryptionErrorMessage` variant. The exhaustive match in `save_message` (`presage/src/manager/registered.rs:1621`) doesn't cover it, causing a compile error when building against the latest `libsignal-service-rs` main.

This adds a match arm that skips saving these messages, consistent with the handling of other non-persistable message types like `ReceiptMessage` and `TypingMessage`.

## Changes

- `presage/src/manager/registered.rs`: Add `ContentBody::DecryptionErrorMessage(_)` arm to the `save_message` match block

## Test plan

- [x] Builds successfully against libsignal-service-rs at `773cc03`