### PR TITLE
Disable CDSI as default feature and fix transitive feature of libsqlite3-sys

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ curve25519-dalek = { git = 'https://github.com/signalapp/curve25519-dalek', tag 
 
 and look at the generated Rust documentation of the `Manager` struct to get started.
 
+### Enable CDSI (Contact Discovery)
+
+The secure contact discovery (from phone numbers) feature depends on `libsignal-net` which chose to depend on `boringSSL`. Unfortunately, we rely on `sqlcipher` which is only compatible with `OpenSSL` > 3.x (their APIs are incompatible, but share names).
+
+To use `cdsi` you can use our fork of libsqlite3-sys with a custom encryption provider written in Rust, like so in your `Cargo.toml`:
+
+```toml
+presage = { git = "https://github.com/whisperfish/presage" }
+presage-sqlite = { git = "https://github.com/whisperfish/presage", default-features = false, features = ["cdsi"] }
+
+[patch.crates-io]
+libsqlite3-sys = { version = "0.36.0", git = "https://github.com/whisperfish/rusqlite", rev = '2a42b3354c9194700d08aa070f70a131a470e7dc' }
+```
+
 ## Demo CLI
 
 Included in this repository is a nearly fully functional CLI that can serve as an example to build your client (you can also use it to query your `presage` database):

--- a/presage-store-sqlite/Cargo.toml
+++ b/presage-store-sqlite/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 license = "AGPL-3.0-only"
 
 [features]
-default = []
+default = ["libsqlite3-sys/bundled-sqlcipher"]
 cdsi = ["presage/cdsi", "libsqlite3-sys/bundled-sqlcipher-custom-crypto"]
 
 [dependencies]

--- a/presage-store-sqlite/Cargo.toml
+++ b/presage-store-sqlite/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 license = "AGPL-3.0-only"
 
 [features]
-default = ["cdsi"]
-cdsi = ["presage/cdsi"]
+default = []
+cdsi = ["presage/cdsi", "libsqlite3-sys/bundled-sqlcipher-custom-crypto"]
 
 [dependencies]
 presage = { path = "../presage", default-features = false }
@@ -23,7 +23,7 @@ tracing = "0.1.41"
 uuid = "1.12.0"
 
 # Explicitly use the libsqlite3-sys crate with the bundled-sqlcipher feature
-libsqlite3-sys = { version = "0.36.0", features = ["bundled-sqlcipher-custom-crypto"] }
+libsqlite3-sys = { version = "0.36.0", features = [] }
 
 [dev-dependencies]
 tokio = { version = "1.48.0", features = ["rt", "macros"] }

--- a/presage/Cargo.toml
+++ b/presage/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "AGPL-3.0-only"
 
 [features]
-default = ["cdsi"]
+default = []
 # brings libsignal-net and all its dependencies
 cdsi = ["libsignal-service/cdsi"]
 


### PR DESCRIPTION
The sqlcipher custom provider we introduced with @rubdos has issues compiling on aarch64, and `cargo` features can only be enabled, which means we need to have users compile presage without default-features + `cdsi` if they want to enable it.