### PR TITLE
fix: archive sessions on DecryptionErrorMessage; fix sqlite address encoding

### DIFF
--- a/presage-store-sqlite/src/protocol.rs
+++ b/presage-store-sqlite/src/protocol.rs
@@ -164,7 +164,12 @@ impl SessionStoreExt for SqliteProtocolStore {
     ///
     /// Returns the number of deleted sessions.
     async fn delete_all_sessions(&self, name: &ServiceId) -> Result<usize, SignalProtocolError> {
-        let address = name.raw_uuid();
+        // Must match the address encoding used by store_session, which keys
+        // rows by ProtocolAddress::name() — i.e. ServiceId::service_id_string()
+        // ("<uuid>" for ACI, "PNI:<uuid>" for PNI). Previously this used
+        // raw_uuid(), which sqlx binds as a 16-byte BLOB, so DELETE never
+        // matched any stored row and the call was a silent no-op.
+        let address = name.service_id_string();
         let res = query!(
             "DELETE FROM sessions WHERE address = ? AND identity = ?",
             address,

--- a/presage/src/manager/mod.rs
+++ b/presage/src/manager/mod.rs
@@ -2,7 +2,8 @@
 
 mod confirmation;
 mod linking;
-mod registered;
+#[doc(hidden)]
+pub mod registered;
 mod registration;
 
 use std::{fmt, sync::Arc};

--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -663,11 +663,7 @@ impl<S: Store> Manager<S, Registered> {
                             };
                             match envelope {
                                 Ok(Some(content)) => {
-                                    if let ContentBody::DecryptionErrorMessage(e) = &content.body {
-                                        error!(
-                                            error = ?e,
-                                            "got error decrypting a message"
-                                        );
+                                    if maybe_handle_decryption_error_message(&state.store, &content).await {
                                         continue;
                                     }
 
@@ -1209,16 +1205,7 @@ impl<S: Store> Manager<S, Registered> {
 
     /// Clears all sessions established with [recipient](ServiceId).
     pub async fn clear_sessions(&self, recipient: &ServiceId) -> Result<(), Error<S::Error>> {
-        use libsignal_service::session_store::SessionStoreExt;
-        self.store
-            .aci_protocol_store()
-            .delete_all_sessions(recipient)
-            .await?;
-        self.store
-            .pni_protocol_store()
-            .delete_all_sessions(recipient)
-            .await?;
-        Ok(())
+        delete_all_sessions_for_recipient(&self.store, recipient).await
     }
 
     /// Downloads and decrypts a single attachment.
@@ -1927,4 +1914,56 @@ async fn register_pre_keys<S: Store>(
 
     trace!("registered pre keys");
     Ok(())
+}
+
+/// Delete every session with `recipient` from both the ACI and PNI protocol
+/// stores. The next outbound message to that recipient will fetch a fresh
+/// prekey bundle and establish a new session.
+#[doc(hidden)]
+pub async fn delete_all_sessions_for_recipient<S: Store>(
+    store: &S,
+    recipient: &ServiceId,
+) -> Result<(), Error<S::Error>> {
+    use libsignal_service::session_store::SessionStoreExt;
+    store
+        .aci_protocol_store()
+        .delete_all_sessions(recipient)
+        .await?;
+    store
+        .pni_protocol_store()
+        .delete_all_sessions(recipient)
+        .await?;
+    Ok(())
+}
+
+/// If `content` carries a [`ContentBody::DecryptionErrorMessage`], log it and
+/// archive (by deleting) every session we hold with the sender so the next
+/// outbound message re-establishes a session from a fresh prekey bundle,
+/// then return `true` to signal the caller should skip further handling of
+/// this envelope. Returns `false` for any other content body.
+///
+/// Factored out of the receive loop so the behaviour — "DEM arrives →
+/// sessions wiped" — is directly unit-testable.
+#[doc(hidden)]
+pub async fn maybe_handle_decryption_error_message<S: Store>(
+    store: &S,
+    content: &Content,
+) -> bool {
+    if let ContentBody::DecryptionErrorMessage(e) = &content.body {
+        let sender = &content.metadata.sender;
+        error!(
+            error = ?e,
+            sender = ?sender,
+            "got DecryptionErrorMessage; archiving sender sessions so next outbound re-establishes from a fresh prekey bundle"
+        );
+        // Without this, both sides stay stuck in a decryption-failure loop:
+        // the peer keeps signalling that our session is bad, we keep reusing
+        // the same ratchet, and the peer keeps rejecting our messages.
+        if let Err(err) = delete_all_sessions_for_recipient(store, sender).await {
+            warn!(?err, "failed to archive sessions for DEM sender");
+        }
+        true
+    } else {
+        false
+    }
 }

--- a/presage/tests/dem_archives_session.rs
+++ b/presage/tests/dem_archives_session.rs
@@ -1,0 +1,166 @@
+//! Integration test for the DecryptionErrorMessage handler that fires inside
+//! `Manager::receive_messages`' receive loop. The handler's job is to wipe
+//! every session held with the sender so that the next outbound message
+//! re-establishes from a fresh prekey bundle. Before it was added, presage
+//! received the peer's session-reset request, logged it, and did nothing —
+//! which left sender and recipient permanently out of sync any time crypto
+//! drift occurred.
+//!
+//! This lives under `tests/` rather than as an inline unit test because
+//! presage depends on presage-store-sqlite only as a dev-dependency, and
+//! presage-store-sqlite itself depends on presage via `path = "../presage"`.
+//! That circularity confuses `cargo test`'s resolver in the same-crate
+//! unit-test slot, but integration tests are compiled as external crates and
+//! avoid it.
+
+use libsignal_service::content::{Content, ContentBody, Metadata};
+use libsignal_service::proto::{DataMessage, DecryptionErrorMessage};
+use libsignal_service::protocol::{
+    DeviceId, ProtocolAddress, ServiceId, SessionRecord, SessionStore,
+};
+use presage::manager::registered::{
+    delete_all_sessions_for_recipient, maybe_handle_decryption_error_message,
+};
+use presage::store::Store;
+use presage_store_sqlite::{OnNewIdentity, SqliteStore};
+
+const SENDER_UUID: &str = "9d0652a3-dcc3-4d11-975f-74d61598733f";
+const DESTINATION_UUID: &str = "11111111-1111-1111-1111-111111111111";
+
+fn sender() -> ServiceId {
+    ServiceId::parse_from_service_id_string(SENDER_UUID).expect("valid UUID")
+}
+
+fn address() -> ProtocolAddress {
+    ProtocolAddress::new(
+        SENDER_UUID.to_string(),
+        DeviceId::try_from(1u32).expect("valid device id"),
+    )
+}
+
+fn content_from_sender(body: ContentBody) -> Content {
+    Content {
+        metadata: Metadata {
+            destination: ServiceId::parse_from_service_id_string(DESTINATION_UUID)
+                .expect("valid UUID"),
+            sender: sender(),
+            sender_device: DeviceId::try_from(1u32).expect("valid device id"),
+            timestamp: 0,
+            needs_receipt: false,
+            unidentified_sender: true,
+            was_plaintext: false,
+            server_guid: None,
+        },
+        body,
+    }
+}
+
+async fn seed_sessions<S: Store>(store: &S) -> Result<(), Box<dyn std::error::Error>> {
+    let mut aci = store.aci_protocol_store();
+    let mut pni = store.pni_protocol_store();
+    aci.store_session(&address(), &SessionRecord::new_fresh())
+        .await?;
+    pni.store_session(&address(), &SessionRecord::new_fresh())
+        .await?;
+    Ok(())
+}
+
+async fn sessions_present<S: Store>(store: &S) -> Result<(bool, bool), Box<dyn std::error::Error>> {
+    let aci = store
+        .aci_protocol_store()
+        .load_session(&address())
+        .await?
+        .is_some();
+    let pni = store
+        .pni_protocol_store()
+        .load_session(&address())
+        .await?
+        .is_some();
+    Ok((aci, pni))
+}
+
+/// Core behaviour change: a sealed-sender DecryptionErrorMessage from a
+/// peer should cause us to wipe both our ACI and PNI sessions for that peer.
+/// Before this change the handler logged the DEM and continued — leaving the
+/// stale ratchet in place, so every subsequent outbound hit the same failure.
+#[tokio::test]
+async fn dem_content_wipes_both_aci_and_pni_sessions_for_sender(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let store = SqliteStore::open(":memory:", OnNewIdentity::Trust).await?;
+
+    seed_sessions(&store).await?;
+    assert_eq!(
+        sessions_present(&store).await?,
+        (true, true),
+        "test setup: sessions seeded in both stores"
+    );
+
+    let dem = DecryptionErrorMessage {
+        timestamp: Some(1),
+        device_id: Some(1),
+        ratchet_key: None,
+    };
+    let content = content_from_sender(ContentBody::DecryptionErrorMessage(dem));
+
+    let handled = maybe_handle_decryption_error_message(&store, &content).await;
+
+    assert!(
+        handled,
+        "DEM content must signal it was handled (caller will skip further processing)"
+    );
+    assert_eq!(
+        sessions_present(&store).await?,
+        (false, false),
+        "both ACI and PNI sessions must be wiped after DEM handling — this is the fix"
+    );
+
+    Ok(())
+}
+
+/// Regression guard: non-DEM contents (DataMessage, SyncMessage, etc.) must
+/// NOT short-circuit the receive loop and must NOT touch any sessions.
+/// Without this guard a future refactor could widen the archival to unrelated
+/// message types and invisibly drop the peer's session every message.
+#[tokio::test]
+async fn data_message_does_not_wipe_sessions(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let store = SqliteStore::open(":memory:", OnNewIdentity::Trust).await?;
+
+    seed_sessions(&store).await?;
+
+    let content = content_from_sender(ContentBody::DataMessage(DataMessage {
+        body: Some("hello".to_string()),
+        ..Default::default()
+    }));
+
+    let handled = maybe_handle_decryption_error_message(&store, &content).await;
+
+    assert!(
+        !handled,
+        "DataMessage content must not short-circuit the receive loop"
+    );
+    assert_eq!(
+        sessions_present(&store).await?,
+        (true, true),
+        "DataMessage must not touch sessions"
+    );
+
+    Ok(())
+}
+
+/// Idempotency: a second DEM from the same sender (likely after they send
+/// another session-restart because they still haven't seen a fresh prekey
+/// message from us) must also succeed with no state change. This guards
+/// against the archival path accidentally erroring on already-empty stores
+/// and letting DEMs leak through to orchestrator-level handling.
+#[tokio::test]
+async fn delete_all_sessions_for_recipient_is_idempotent(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let store = SqliteStore::open(":memory:", OnNewIdentity::Trust).await?;
+
+    // No sessions seeded; deleting should still be a clean no-op.
+    delete_all_sessions_for_recipient(&store, &sender()).await?;
+    delete_all_sessions_for_recipient(&store, &sender()).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #399. Companion to whisperfish/libsignal-service-rs#428 — see the issue for full context on how the two fixes interact.

## Summary

Two compounding bugs turn any Signal-session crypto drift between this client and a peer into a permanent decryption-failure loop. This PR fixes both.

### 1. Receive loop drops the peer's session-reset request

When a peer can't decrypt our message, their client sends a `DecryptionErrorMessage` asking us to rebuild the session from a fresh prekey bundle. The existing handler in `registered.rs` logs it and does nothing else. Our next outbound reuses the stale ratchet, the peer sends another DEM, we log-and-ignore that one too — forever.

Fix: extract the DEM handling into `maybe_handle_decryption_error_message(store, content)` so the behaviour is directly testable, and call `delete_all_sessions_for_recipient` inside it. When a DEM fires, the sender's sessions are deleted from both ACI and PNI stores so the next outbound re-establishes via prekey bundle.

**Note on scope**: sealed-sender `PlaintextContent` envelopes currently fail at the libsignal-service-rs cipher layer before reaching this handler — the companion fix at whisperfish/libsignal-service-rs#428 unblocks that path. The non-sealed `Type::PlaintextContent` path (fixed for decoding in ce73b53) has been reaching this handler since 2023 and was equally silent about session recovery, so this PR is valuable on its own.

### 2. `SqliteProtocolStore::delete_all_sessions` was a silent no-op

`store_session` keys rows by `ProtocolAddress::name()` — the text form `ServiceId::service_id_string()` produces (`"<uuid>"` for ACI, `"PNI:<uuid>"` for PNI). `delete_all_sessions` was querying by `raw_uuid()`, which sqlx binds as a 16-byte BLOB, so the DELETE never matched any stored row. This also made `Manager::clear_sessions` — the existing public API for the same purpose — equally broken, which is presumably why nobody noticed: no existing code path actually relied on the delete removing anything. The new DEM-archival path is the first caller that does, and the test caught it.

Fix: use `name.service_id_string()` to match the address encoding that `store_session` writes.

## Test

Integration test in `presage/tests/dem_archives_session.rs` exercises the fix against a real in-memory `SqliteStore` rather than a mock:

- `dem_content_wipes_both_aci_and_pni_sessions_for_sender` seeds a session in each store, feeds a `Content` with `ContentBody::DecryptionErrorMessage`, and asserts the sessions are gone afterwards.
- `data_message_does_not_wipe_sessions` is a regression guard so a future refactor can't accidentally widen archival to unrelated message types.
- `delete_all_sessions_for_recipient_is_idempotent` covers repeated DEMs from the same sender.

Lives under `tests/` because presage-store-sqlite depends on presage via a path, creating a circular-compilation issue in the same-crate unit-test slot that integration tests avoid. `maybe_handle_decryption_error_message` and `delete_all_sessions_for_recipient` are therefore `pub #[doc(hidden)]` so the integration test can reach them without widening the real API; `manager::registered` is likewise `pub mod` with `#[doc(hidden)]`.

## Test plan

- [x] `cargo test -p presage --test dem_archives_session` — 3 passed
- [x] Full workspace `cargo test` — all suites pass, no new warnings
- [x] Deployed to production; pending behavioural confirmation as the next drift event from a real peer is observed