### PR TITLE
Fix opening the Sqlite store without a passphrase

### DIFF
--- a/presage-store-sqlite/src/lib.rs
+++ b/presage-store-sqlite/src/lib.rs
@@ -34,8 +34,7 @@ impl SqliteStore {
         url: &str,
         trust_new_identities: OnNewIdentity,
     ) -> Result<Self, SqliteStoreError> {
-        let options: SqliteConnectOptions = url.parse()?;
-        Self::open_with_options(options, trust_new_identities).await
+        Self::open_with_passphrase(url, None, trust_new_identities).await
     }
 
     pub async fn open_with_passphrase(


### PR DESCRIPTION
The `open` function did not set `crate_if_missing` or `foreign_keys` open options, with the `create_if_missing` one preventing usage of `open` alone. Replace the `open`-code to just call `open_with_passphrase` with `passphrase = None`.