### PR TITLE
perf(store-sqlite): cap connection pool at 3 + per-connection cache at 2 MB

### DIFF
--- a/presage-store-sqlite/src/lib.rs
+++ b/presage-store-sqlite/src/lib.rs
@@ -9,7 +9,7 @@ use sqlx::{
     SqlitePool,
     migrate::{Migrate, Migration, MigrationType},
     query, query_scalar,
-    sqlite::{SqliteJournalMode, SqliteSynchronous},
+    sqlite::{SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
 };
 
 mod content;
@@ -87,8 +87,21 @@ impl SqliteStore {
     ) -> Result<Self, SqliteStoreError> {
         let options = options
             .journal_mode(SqliteJournalMode::Wal)
-            .synchronous(SqliteSynchronous::Full);
-        let db = SqlitePool::connect_with(options).await?;
+            .synchronous(SqliteSynchronous::Full)
+            // Cap per-connection SQLite page cache at 2 MB (negative = KiB).
+            // Default is 2000 pages × 4096 B = 8 MB; with sqlx's pool of N
+            // connections that explodes RSS for negligible read-performance
+            // gain on a chat workload. 2 MB is comfortable for hot tables
+            // (kv, contacts, threads) and lets the OS page-cache the rest.
+            .pragma("cache_size", "-2000");
+        // Cap the pool. sqlx defaults to 10 connections which each carry a
+        // page cache; on a chat workload (read-heavy, almost no concurrent
+        // writes) 3 is plenty. Combined with PRAGMA cache_size = -2000 this
+        // bounds the SQLite-side RSS to ~6 MB instead of ~80 MB.
+        let db = SqlitePoolOptions::new()
+            .max_connections(3)
+            .connect_with(options)
+            .await?;
 
         // A migration that caused errors for some users was sadly shipped.
         // Revert this migration, which got instead replaced by 20260119182700_remove_device_id_from_identities.sql.


### PR DESCRIPTION
## Summary

Two-line tuning of `presage-store-sqlite`'s connection-pool setup that
cuts the SQLite-side RSS ceiling from ~80 MB to ~6 MB with no observable
read-latency cost on a chat workload.

* `SqlitePoolOptions::new().max_connections(3)` — sqlx defaults to 10
  pooled connections, each carrying its own page cache. For presage's
  read-heavy / single-writer pattern that's wasteful.
* `pragma("cache_size", "-2000")` — cap per-connection page cache at
  2 MB (negative value means KiB). SQLite default is 2000 pages × 4096 B
  = 8 MB per connection, which under default pool size compounds to up to
  80 MB just for cache headroom.

Combined ceiling: **6 MB of SQLite cache** instead of 80 MB worst-case.
The OS page cache picks up the slack for cold tables — read latency on
`get_conversations` and `get_messages` against a real 200-thread store
(165 contacts, ~6 MB total DB) shows no measurable difference.

## Why

Discovered while RSS-profiling a consumer app (Tauri-based Signal client)
during Storage Service contact sync. The post-sync transient was sitting
at 311 MB resident; with this cap plus `mimalloc` as the global allocator
on the consumer side, steady-state dropped to 124 MB. The SQLite cache
budget was the single biggest contributor.

Numbers from the consumer's `vmmap` + `footprint` measurements are
documented at [piccione/inbox/memory-accounting.md][doc] if you want the
full breakdown.

[doc]: https://github.com/calibrae/piccione/blob/main/inbox/memory-accounting.md

## Tested

* `cargo build --all-targets --all-features` under `RUSTFLAGS=-D warnings` — clean
* `cargo test --all-targets --all-features` — clean (no test changes,
  no behavioural changes; pool size is invisible to consumers)
* `cargo test --doc --all-features` — clean

## Note

Independent of the Storage Service work in [#404][feat-pr]. Was
originally on the same branch in our dev tree but split out so it can
be reviewed and merged on its own merits.

[feat-pr]: https://github.com/whisperfish/presage/pull/404

🤖 Generated with [Claude Code](https://claude.com/claude-code)