### PR TITLE
Allow non-mutable references for all store functions and some manager functions

### DIFF
--- a/presage-cli/src/main.rs
+++ b/presage-cli/src/main.rs
@@ -770,7 +770,7 @@ async fn run<S: Store>(subcommand: Cmd, store: S) -> anyhow::Result<()> {
             uuid,
             mut profile_key,
         } => {
-            let mut manager = load_registered_and_receive(store).await?;
+            let manager = load_registered_and_receive(store).await?;
             if profile_key.is_none() {
                 for contact in manager
                     .store()

--- a/presage-store-sqlite/src/content.rs
+++ b/presage-store-sqlite/src/content.rs
@@ -39,7 +39,7 @@ impl ContentsStore for SqliteStore {
     type StickerPacksIter =
         Box<dyn Iterator<Item = Result<StickerPack, Self::ContentsStoreError>> + Send + Sync>;
 
-    async fn clear_profiles(&mut self) -> Result<(), Self::ContentsStoreError> {
+    async fn clear_profiles(&self) -> Result<(), Self::ContentsStoreError> {
         let mut transaction = self.db.begin().await.into_protocol_error()?;
         query!("DELETE FROM profiles")
             .execute(&mut *transaction)
@@ -54,7 +54,7 @@ impl ContentsStore for SqliteStore {
         Ok(())
     }
 
-    async fn clear_contents(&mut self) -> Result<(), Self::ContentsStoreError> {
+    async fn clear_contents(&self) -> Result<(), Self::ContentsStoreError> {
         let mut transaction = self.db.begin().await.into_protocol_error()?;
         query!("DELETE FROM thread_messages")
             .execute(&mut *transaction)
@@ -81,7 +81,7 @@ impl ContentsStore for SqliteStore {
         Ok(())
     }
 
-    async fn clear_messages(&mut self) -> Result<(), Self::ContentsStoreError> {
+    async fn clear_messages(&self) -> Result<(), Self::ContentsStoreError> {
         let mut transaction = self.db.begin().await.into_protocol_error()?;
         query!("DELETE FROM thread_messages")
             .execute(&mut *transaction)
@@ -93,7 +93,7 @@ impl ContentsStore for SqliteStore {
         Ok(())
     }
 
-    async fn clear_thread(&mut self, thread: &Thread) -> Result<(), Self::ContentsStoreError> {
+    async fn clear_thread(&self, thread: &Thread) -> Result<(), Self::ContentsStoreError> {
         let (group_master_key, recipient_id) = thread.unzip();
         query!(
             "DELETE FROM thread_messages WHERE thread_id = (
@@ -187,7 +187,7 @@ impl ContentsStore for SqliteStore {
     }
 
     async fn delete_message(
-        &mut self,
+        &self,
         thread: &Thread,
         timestamp: u64,
     ) -> Result<bool, Self::ContentsStoreError> {
@@ -280,7 +280,7 @@ impl ContentsStore for SqliteStore {
         Ok(Box::new(rows.into_iter().map(TryInto::try_into)))
     }
 
-    async fn clear_contacts(&mut self) -> Result<(), Self::ContentsStoreError> {
+    async fn clear_contacts(&self) -> Result<(), Self::ContentsStoreError> {
         let mut transaction = self.db.begin().await.into_protocol_error()?;
         query!("DELETE FROM contacts")
             .execute(&mut *transaction)
@@ -292,7 +292,7 @@ impl ContentsStore for SqliteStore {
         Ok(())
     }
 
-    async fn save_contact(&mut self, contact: &Contact) -> Result<(), Self::ContentsStoreError> {
+    async fn save_contact(&self, contact: &Contact) -> Result<(), Self::ContentsStoreError> {
         let profile_key: &[u8] = contact.profile_key.as_ref();
         let avatar_bytes = contact.avatar.as_ref().map(|a| a.reader.to_vec());
         let phone_number = contact.phone_number.as_ref().map(|p| p.to_string());
@@ -400,7 +400,7 @@ impl ContentsStore for SqliteStore {
         .transpose()
     }
 
-    async fn clear_groups(&mut self) -> Result<(), Self::ContentsStoreError> {
+    async fn clear_groups(&self) -> Result<(), Self::ContentsStoreError> {
         let mut transaction = self.db.begin().await.into_protocol_error()?;
         query!("DELETE FROM groups")
             .execute(&mut *transaction)
@@ -521,7 +521,7 @@ impl ContentsStore for SqliteStore {
     }
 
     async fn upsert_profile_key(
-        &mut self,
+        &self,
         uuid: &Uuid,
         key: ProfileKey,
     ) -> Result<bool, Self::ContentsStoreError> {
@@ -549,7 +549,7 @@ impl ContentsStore for SqliteStore {
     }
 
     async fn save_profile(
-        &mut self,
+        &self,
         uuid: Uuid,
         key: ProfileKey,
         profile: Profile,
@@ -606,7 +606,7 @@ impl ContentsStore for SqliteStore {
     }
 
     async fn save_profile_avatar(
-        &mut self,
+        &self,
         uuid: Uuid,
         _key: ProfileKey,
         profile: &AvatarBytes,
@@ -632,10 +632,7 @@ impl ContentsStore for SqliteStore {
             .map_err(From::from)
     }
 
-    async fn add_sticker_pack(
-        &mut self,
-        pack: &StickerPack,
-    ) -> Result<(), Self::ContentsStoreError> {
+    async fn add_sticker_pack(&self, pack: &StickerPack) -> Result<(), Self::ContentsStoreError> {
         let manifest_json = Json(&pack.manifest);
         query!(
             "INSERT OR REPLACE INTO sticker_packs(id, key, manifest) VALUES(?, ?, ?)",
@@ -662,7 +659,7 @@ impl ContentsStore for SqliteStore {
         Ok(pack.map(From::from))
     }
 
-    async fn remove_sticker_pack(&mut self, id: &[u8]) -> Result<bool, Self::ContentsStoreError> {
+    async fn remove_sticker_pack(&self, id: &[u8]) -> Result<bool, Self::ContentsStoreError> {
         let res = query!("DELETE FROM sticker_packs WHERE id = ?", id)
             .execute(&self.db)
             .await?;

--- a/presage-store-sqlite/src/lib.rs
+++ b/presage-store-sqlite/src/lib.rs
@@ -175,7 +175,7 @@ impl Store for SqliteStore {
 
     type PniStore = SqliteProtocolStore;
 
-    async fn clear(&mut self) -> Result<(), SqliteStoreError> {
+    async fn clear(&self) -> Result<(), SqliteStoreError> {
         query!("DELETE FROM kv").execute(&self.db).await?;
         Ok(())
     }
@@ -210,7 +210,7 @@ impl StateStore for SqliteStore {
     }
 
     async fn save_registration_data(
-        &mut self,
+        &self,
         state: &presage::manager::RegistrationData,
     ) -> Result<(), Self::StateStoreError> {
         let value = serde_json::to_string(state)?;
@@ -227,7 +227,7 @@ impl StateStore for SqliteStore {
         self.load_registration_data().await.ok().flatten().is_some()
     }
 
-    async fn clear_registration(&mut self) -> Result<(), Self::StateStoreError> {
+    async fn clear_registration(&self) -> Result<(), Self::StateStoreError> {
         let mut transaction = self.db.begin().await.into_protocol_error()?;
         query!("DELETE FROM kv WHERE key = 'registration'")
             .execute(&mut *transaction)

--- a/presage/src/manager/confirmation.rs
+++ b/presage/src/manager/confirmation.rs
@@ -136,7 +136,7 @@ impl<S: Store> Manager<S, Confirmation> {
             )
             .await?;
 
-        let mut manager = Manager {
+        let manager = Manager {
             store: self.store,
             state: Arc::new(Registered::with_data(RegistrationData {
                 signal_servers: self.state.signal_servers,

--- a/presage/src/manager/linking.rs
+++ b/presage/src/manager/linking.rs
@@ -61,7 +61,7 @@ impl<S: Store> Manager<S, Linking> {
     /// }
     /// ```
     pub async fn link_secondary_device(
-        mut store: S,
+        store: S,
         signal_servers: SignalServers,
         device_name: String,
         provisioning_link_channel: oneshot::Sender<Url>,

--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -365,14 +365,14 @@ impl<S: Store> Manager<S, Registered> {
     }
 
     /// Fetches the profile (name, about, status emoji) of the registered user.
-    pub async fn retrieve_profile(&mut self) -> Result<Profile, Error<S::Error>> {
+    pub async fn retrieve_profile(&self) -> Result<Profile, Error<S::Error>> {
         self.retrieve_profile_by_uuid(self.state.data.service_ids.aci, self.state.data.profile_key)
             .await
     }
 
     /// Fetches the profile of the provided user by UUID and profile key.
     pub async fn retrieve_profile_by_uuid(
-        &mut self,
+        &self,
         aci: impl Into<Aci>,
         profile_key: ProfileKey,
     ) -> Result<Profile, Error<S::Error>> {
@@ -442,7 +442,7 @@ impl<S: Store> Manager<S, Registered> {
     }
 
     pub async fn retrieve_group_avatar(
-        &mut self,
+        &self,
         context: GroupContextV2,
     ) -> Result<Option<AvatarBytes>, Error<S::Error>> {
         let master_key_bytes = context
@@ -492,7 +492,7 @@ impl<S: Store> Manager<S, Registered> {
     }
 
     pub async fn retrieve_profile_avatar_by_uuid(
-        &mut self,
+        &self,
         uuid: Uuid,
         profile_key: ProfileKey,
     ) -> Result<Option<AvatarBytes>, Error<S::Error>> {
@@ -898,7 +898,7 @@ impl<S: Store> Manager<S, Registered> {
                                     }
 
                                     if let Err(error) = save_message(
-                                        &mut state.store,
+                                        &state.store,
                                         &mut state.identified_websocket,
                                         content.clone(),
                                         None,
@@ -1053,7 +1053,7 @@ impl<S: Store> Manager<S, Registered> {
 
         let mut identified_websocket = self.identified_websocket(false).await?;
         save_message(
-            &mut self.store,
+            &self.store,
             &mut identified_websocket,
             content,
             Some(thread),
@@ -1179,7 +1179,7 @@ impl<S: Store> Manager<S, Registered> {
 
         let mut identified_websocket = self.identified_websocket(false).await?;
         save_message(
-            &mut self.store,
+            &self.store,
             &mut identified_websocket,
             content,
             Some(thread),
@@ -1189,7 +1189,7 @@ impl<S: Store> Manager<S, Registered> {
         Ok(())
     }
 
-    async fn restore_thread_timer(&mut self, thread: &Thread, content_body: &mut ContentBody) {
+    async fn restore_thread_timer(&self, thread: &Thread, content_body: &mut ContentBody) {
         let store_expire_timer = self.store.expire_timer(thread).await.unwrap_or_default();
 
         if let ContentBody::DataMessage(DataMessage {
@@ -1273,7 +1273,7 @@ impl<S: Store> Manager<S, Registered> {
 
     /// Gets the metadata of a sticker
     pub async fn sticker_metadata(
-        &mut self,
+        &self,
         pack_id: &[u8],
         sticker_id: u32,
     ) -> Result<Option<Sticker>, Error<S::Error>> {
@@ -1580,7 +1580,7 @@ async fn upsert_group<S: Store>(
 
 /// Download and decrypt a sticker manifest
 async fn download_sticker_pack<C: ContentsStore>(
-    mut store: C,
+    store: C,
     mut unidentified_websocket: SignalWebSocket<websocket::Unidentified>,
     operation: &StickerPackOperation,
 ) -> Result<StickerPack, Error<C::ContentsStoreError>> {
@@ -1657,7 +1657,7 @@ async fn download_sticker<C: ContentsStore>(
 /// Note that `override_thread` can be used to specify the thread the message will be stored in.
 /// This is required when storing outgoing messages, as in this case the appropriate storage place cannot be derived from the message itself.
 async fn save_message<S: Store>(
-    store: &mut S,
+    store: &S,
     identified_websocket: &mut websocket::SignalWebSocket<websocket::Identified>,
     message: Content,
     override_thread: Option<Thread>,
@@ -1820,7 +1820,7 @@ async fn save_message<S: Store>(
 }
 
 async fn upsert_contact_from_profile<S: Store>(
-    mut store: S,
+    store: S,
     mut identified_websocket: SignalWebSocket<websocket::Identified>,
     data_message: &DataMessage,
     sender: ServiceId,

--- a/presage/src/manager/registration.rs
+++ b/presage/src/manager/registration.rs
@@ -63,7 +63,7 @@ impl<S: Store> Manager<S, Registration> {
     /// }
     /// ```
     pub async fn register(
-        mut store: S,
+        store: S,
         registration_options: RegistrationOptions<'_>,
     ) -> Result<Manager<S, Confirmation>, Error<S::Error>> {
         let RegistrationOptions {

--- a/presage/src/store.rs
+++ b/presage/src/store.rs
@@ -53,7 +53,7 @@ pub trait StateStore {
 
     /// Save registered (or linked) state
     fn save_registration_data(
-        &mut self,
+        &self,
         state: &RegistrationData,
     ) -> impl Future<Output = Result<(), Self::StateStoreError>> + Send;
 
@@ -70,7 +70,7 @@ pub trait StateStore {
     fn is_registered(&self) -> impl Future<Output = bool>;
 
     /// Clear registration data (including keys), but keep received messages, groups and contacts.
-    fn clear_registration(&mut self) -> impl Future<Output = Result<(), Self::StateStoreError>>;
+    fn clear_registration(&self) -> impl Future<Output = Result<(), Self::StateStoreError>>;
 
     fn fetch_master_key(
         &self,
@@ -101,19 +101,19 @@ pub trait ContentsStore: Send + Sync {
     type StickerPacksIter: Iterator<Item = Result<StickerPack, Self::ContentsStoreError>>;
 
     // Clear all profiles
-    fn clear_profiles(&mut self) -> impl Future<Output = Result<(), Self::ContentsStoreError>>;
+    fn clear_profiles(&self) -> impl Future<Output = Result<(), Self::ContentsStoreError>>;
 
     // Clear all stored messages
-    fn clear_contents(&mut self) -> impl Future<Output = Result<(), Self::ContentsStoreError>>;
+    fn clear_contents(&self) -> impl Future<Output = Result<(), Self::ContentsStoreError>>;
 
     // Messages
 
     /// Clear all stored messages.
-    fn clear_messages(&mut self) -> impl Future<Output = Result<(), Self::ContentsStoreError>>;
+    fn clear_messages(&self) -> impl Future<Output = Result<(), Self::ContentsStoreError>>;
 
     /// Clear the messages in a thread.
     fn clear_thread(
-        &mut self,
+        &self,
         thread: &Thread,
     ) -> impl Future<Output = Result<(), Self::ContentsStoreError>>;
 
@@ -127,7 +127,7 @@ pub trait ContentsStore: Send + Sync {
     /// Delete a single message, identified by its received timestamp from a thread.
     /// Useful when you want to delete a message locally only.
     fn delete_message(
-        &mut self,
+        &self,
         thread: &Thread,
         timestamp: u64,
     ) -> impl Future<Output = Result<bool, Self::ContentsStoreError>>;
@@ -171,7 +171,7 @@ pub trait ContentsStore: Send + Sync {
     /// Update the expire timer from a [Thread], which corresponds to either [Contact::expire_timer]
     /// or [Group::disappearing_messages_timer].
     fn update_expire_timer(
-        &mut self,
+        &self,
         thread: &Thread,
         timer: u32,
         version: u32,
@@ -207,11 +207,11 @@ pub trait ContentsStore: Send + Sync {
     // Contacts
 
     /// Clear all saved synchronized contact data
-    fn clear_contacts(&mut self) -> impl Future<Output = Result<(), Self::ContentsStoreError>>;
+    fn clear_contacts(&self) -> impl Future<Output = Result<(), Self::ContentsStoreError>>;
 
     /// Save a contact
     fn save_contact(
-        &mut self,
+        &self,
         contacts: &Contact,
     ) -> impl Future<Output = Result<(), Self::ContentsStoreError>> + Send;
 
@@ -227,7 +227,7 @@ pub trait ContentsStore: Send + Sync {
     ) -> impl Future<Output = Result<Option<Contact>, Self::ContentsStoreError>> + Send;
 
     /// Delete all cached group data
-    fn clear_groups(&mut self) -> impl Future<Output = Result<(), Self::ContentsStoreError>>;
+    fn clear_groups(&self) -> impl Future<Output = Result<(), Self::ContentsStoreError>>;
 
     /// Save a group in the cache
     fn save_group(
@@ -262,7 +262,7 @@ pub trait ContentsStore: Send + Sync {
 
     /// Insert or update the profile key of a contact
     fn upsert_profile_key(
-        &mut self,
+        &self,
         uuid: &Uuid,
         key: ProfileKey,
     ) -> impl Future<Output = Result<bool, Self::ContentsStoreError>> + Send;
@@ -275,7 +275,7 @@ pub trait ContentsStore: Send + Sync {
 
     /// Save a profile by [Uuid] and [ProfileKey].
     fn save_profile(
-        &mut self,
+        &self,
         uuid: Uuid,
         key: ProfileKey,
         profile: Profile,
@@ -290,7 +290,7 @@ pub trait ContentsStore: Send + Sync {
 
     /// Save a profile avatar by [Uuid] and [ProfileKey].
     fn save_profile_avatar(
-        &mut self,
+        &self,
         uuid: Uuid,
         key: ProfileKey,
         profile: &AvatarBytes,
@@ -307,7 +307,7 @@ pub trait ContentsStore: Send + Sync {
 
     /// Add a sticker pack
     fn add_sticker_pack(
-        &mut self,
+        &self,
         pack: &StickerPack,
     ) -> impl Future<Output = Result<(), Self::ContentsStoreError>> + Send;
 
@@ -319,7 +319,7 @@ pub trait ContentsStore: Send + Sync {
 
     /// Removes a sticker pack
     fn remove_sticker_pack(
-        &mut self,
+        &self,
         id: &[u8],
     ) -> impl Future<Output = Result<bool, Self::ContentsStoreError>>;
 
@@ -358,7 +358,7 @@ pub trait Store:
     ///
     /// This can be useful when resetting an existing client.
     fn clear(
-        &mut self,
+        &self,
     ) -> impl Future<Output = Result<(), <Self as StateStore>::StateStoreError>> + Send;
 
     fn aci_protocol_store(&self) -> Self::AciStore;


### PR DESCRIPTION
This allows parallelizing e.g. fetching avatars. I've kept functions that send messages mut, as those should (to my knowledge) not allow parallel execution.