### PR TITLE
Store receipt messages

### DIFF
--- a/presage/src/manager/registered.rs
+++ b/presage/src/manager/registered.rs
@@ -1790,10 +1790,7 @@ async fn save_message<S: Store>(
             );
             None
         }
-        ContentBody::ReceiptMessage(msg) => {
-            debug!(?msg, "skipping saving receipt message");
-            None
-        }
+        ContentBody::ReceiptMessage(_) => Some(message),
         ContentBody::TypingMessage(msg) => {
             debug!(?msg, "skipping saving typing message");
             None


### PR DESCRIPTION
Before this change, it was impossible to e.g. have a window about who received/read a message (except for messages received while the app is running). By storing receipt messages, those can now be consumed by downstream apps when querying the store.